### PR TITLE
Add website and repo links to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
     "postinstall:workspaces": "npm run build",
     "test": "jest --config jest_node.config.js && jest --config jest_jsdom.config.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "github.com/turbopuffer/turbopuffer-typescript"
-  },
+  "homepage": "https://turbopuffer.com",
+  "repository": "https://github.com/turbopuffer/turbopuffer-typescript.git",
   "author": "Morgan Gallant <morgan@turbopuffer.com>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
I noticed that the [npm page](https://www.npmjs.com/package/@turbopuffer/turbopuffer) doesn’t have the links like I’m used to seeing (repo and homepage). I looked into it and I think it needs to follow this format in the package.json to be picked up on that page and other websites.