### PR TITLE
Etcd/run format and lint

### DIFF
--- a/jest_jsdom.config.js
+++ b/jest_jsdom.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
 };

--- a/jest_node.config.js
+++ b/jest_node.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
-  };
+  preset: "ts-jest",
+  testEnvironment: "node",
+};

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -11,7 +11,9 @@ test("sanity", async () => {
 
   try {
     await ns.deleteAll();
-  } catch (_: unknown) {}
+  } catch (_: unknown) {
+    /* empty */
+  }
 
   await ns.upsert({
     vectors: [

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -1,7 +1,7 @@
 import { Turbopuffer } from "./turbopuffer";
 
 const tpuf = new Turbopuffer({
-  apiKey: process.env.TURBOPUFFER_API_KEY as string,
+  apiKey: process.env.TURBOPUFFER_API_KEY!,
 });
 
 test("sanity", async () => {
@@ -43,7 +43,7 @@ test("sanity", async () => {
   expect(results[0].id).toEqual(2);
   expect(results[1].id).toEqual(1);
 
-  let results2 = await ns.query({
+  const results2 = await ns.query({
     vector: [1, 1],
     filters: [
       "And",
@@ -69,7 +69,7 @@ test("sanity", async () => {
   expect(results2[0].id).toEqual(2);
   expect(results2[1].id).toEqual(1);
 
-  let recall = await ns.recall({
+  const recall = await ns.recall({
     num: 1,
     top_k: 2,
   });

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -11,7 +11,7 @@ test("sanity", async () => {
 
   try {
     await ns.deleteAll();
-  } catch (_: any) {}
+  } catch (_: unknown) {}
 
   await ns.upsert({
     vectors: [
@@ -98,7 +98,7 @@ test("sanity", async () => {
       vector: [1, 1],
       filters: ["numbers", "In", [2, 4]],
     });
-  } catch (_: any) {
+  } catch (_: unknown) {
     gotError = true;
   }
   expect(gotError).toBe(true);

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -69,7 +69,7 @@ export class TurbopufferError extends Error {
   status?: number;
   constructor(
     public error: string,
-    { status }: { status?: number },
+    { status }: { status?: number }
   ) {
     super(error);
     this.status = status;
@@ -111,7 +111,7 @@ export class Turbopuffer {
     method: string;
     path: string;
     query?: Record<string, string | undefined>;
-    body?: any;
+    body?: unknown;
     compress?: boolean;
     retryable?: boolean;
   }): Promise<{ body?: T; headers: Headers }> {
@@ -164,14 +164,14 @@ export class Turbopuffer {
             } else {
               message = JSON.stringify(body);
             }
-          } catch (_: any) {}
+          } catch (_: unknown) {}
         } else {
           try {
             const body = await response.text();
             if (body) {
               message = body;
             }
-          } catch (_: any) {}
+          } catch (_: unknown) {}
         }
         error = new TurbopufferError(message || response.statusText, {
           status: response.status,
@@ -445,7 +445,7 @@ function fromColumnar(cv: ColumnarVectors): Vector[] {
       vector: cv.vectors[i],
       attributes: cv.attributes
         ? Object.fromEntries(
-            attributeEntries.map(([key, values]) => [key, values[i]]),
+            attributeEntries.map(([key, values]) => [key, values[i]])
           )
         : undefined,
     };

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -164,14 +164,18 @@ export class Turbopuffer {
             } else {
               message = JSON.stringify(body);
             }
-          } catch (_: unknown) {}
+          } catch (_: unknown) {
+            /* empty */
+          }
         } else {
           try {
             const body = await response.text();
             if (body) {
               message = body;
             }
-          } catch (_: unknown) {}
+          } catch (_: unknown) {
+            /* empty */
+          }
         }
         error = new TurbopufferError(message ?? response.statusText, {
           status: response.status,

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -7,7 +7,7 @@
 
 import pako from "pako";
 import "isomorphic-fetch";
-import {version} from '../package.json';
+import { version } from "../package.json";
 
 /**
  * Utility Types
@@ -16,14 +16,12 @@ import {version} from '../package.json';
  */
 export type Id = string | number;
 export type AttributeType = null | string | number | string[] | number[];
-export type Attributes = {
-  [key: string]: AttributeType;
-};
-export type Vector = {
+export type Attributes = Record<string, AttributeType>;
+export interface Vector {
   id: Id;
   vector?: number[];
   attributes?: Attributes;
-};
+}
 export type DistanceMetric = "cosine_distance" | "euclidean_squared";
 export type FilterOperator =
   | "Eq"
@@ -50,28 +48,28 @@ export type QueryResults = {
   attributes?: Attributes;
   dist?: number;
 }[];
-export type NamespaceDesc = {
+export interface NamespaceDesc {
   id: string;
   approx_count: number;
   dimensions: number;
   created_at: string; // RFC3339 format
-};
-export type NamespacesListResult = {
+}
+export interface NamespacesListResult {
   namespaces: NamespaceDesc[];
   next_cursor?: string;
-};
-export type RecallMeasurement = {
+}
+export interface RecallMeasurement {
   avg_recall: number;
   avg_exhaustive_count: number;
   avg_ann_count: number;
-};
+}
 
 /* Error type */
 export class TurbopufferError extends Error {
   status?: number;
   constructor(
     public error: string,
-    { status }: { status?: number }
+    { status }: { status?: number },
   ) {
     super(error);
     this.status = status;
@@ -112,9 +110,7 @@ export class Turbopuffer {
   }: {
     method: string;
     path: string;
-    query?: {
-      [key: string]: string | undefined;
-    };
+    query?: Record<string, string | undefined>;
     body?: any;
     compress?: boolean;
     retryable?: boolean;
@@ -122,14 +118,14 @@ export class Turbopuffer {
     const url = new URL(`${this.baseUrl}${path}`);
     if (query) {
       Object.keys(query).forEach((key) => {
-        let value = query[key];
+        const value = query[key];
         if (value) {
           url.searchParams.append(key, value);
         }
       });
     }
 
-    let headers: Record<string, string> = {
+    const headers: Record<string, string> = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       "Accept-Encoding": "gzip",
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -150,8 +146,8 @@ export class Turbopuffer {
     }
 
     const maxAttempts = retryable ? 3 : 1;
-    var response!: Response;
-    var error: TurbopufferError | null = null;
+    let response!: Response;
+    let error: TurbopufferError | null = null;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       response = await fetch(url.toString(), {
         method,
@@ -162,7 +158,7 @@ export class Turbopuffer {
         let message: string | undefined = undefined;
         if (response.headers.get("Content-Type") === "application/json") {
           try {
-            let body = await response.json();
+            const body = await response.json();
             if (body && body.status === "error") {
               message = body.error;
             } else {
@@ -171,13 +167,15 @@ export class Turbopuffer {
           } catch (_: any) {}
         } else {
           try {
-            let body = await response.text();
+            const body = await response.text();
             if (body) {
               message = body;
             }
           } catch (_: any) {}
         }
-        error = new TurbopufferError(message || response.statusText, { status: response.status });
+        error = new TurbopufferError(message || response.statusText, {
+          status: response.status,
+        });
       }
       if (
         error &&
@@ -332,7 +330,7 @@ export class Namespace {
     cursor?: string;
   }): Promise<{ vectors: Vector[]; next_cursor?: string }> {
     type responseType = ColumnarVectors & { next_cursor: string };
-    let response = await this.client.doRequest<responseType>({
+    const response = await this.client.doRequest<responseType>({
       method: "GET",
       path: `/v1/vectors/${this.id}`,
       query: { cursor: params?.cursor },
@@ -349,12 +347,12 @@ export class Namespace {
    * Fetches the approximate number of vectors in a namespace.
    */
   async approxNumVectors(): Promise<number> {
-    let response = await this.client.doRequest<{}>({
+    const response = await this.client.doRequest<{}>({
       method: "HEAD",
       path: `/v1/vectors/${this.id}`,
       retryable: true,
     });
-    let num = response.headers.get("X-turbopuffer-Approx-Num-Vectors");
+    const num = response.headers.get("X-turbopuffer-Approx-Num-Vectors");
     return num ? parseInt(num) : 0;
   }
 
@@ -406,14 +404,12 @@ export class Namespace {
 
 /* Helpers */
 
-type ColumnarAttributes = {
-  [key: string]: AttributeType[];
-};
-type ColumnarVectors = {
+type ColumnarAttributes = Record<string, AttributeType[]>;
+interface ColumnarVectors {
   ids: Id[];
   vectors: number[][];
   attributes?: ColumnarAttributes;
-};
+}
 
 // Unused atm.
 function toColumnar(vectors: Vector[]): ColumnarVectors {
@@ -424,9 +420,9 @@ function toColumnar(vectors: Vector[]): ColumnarVectors {
       attributes: {},
     };
   }
-  let attributes: ColumnarAttributes = {};
+  const attributes: ColumnarAttributes = {};
   vectors.forEach((vec, i) => {
-    for (let [key, val] of Object.entries(vec.attributes || {})) {
+    for (const [key, val] of Object.entries(vec.attributes || {})) {
       if (!attributes[key]) {
         attributes[key] = new Array<AttributeType>(vectors.length).fill(null);
       }
@@ -441,7 +437,7 @@ function toColumnar(vectors: Vector[]): ColumnarVectors {
 }
 
 function fromColumnar(cv: ColumnarVectors): Vector[] {
-  let res = new Array<Vector>(cv.ids.length);
+  const res = new Array<Vector>(cv.ids.length);
   const attributeEntries = Object.entries(cv.attributes || {});
   for (let i = 0; i < cv.ids.length; i++) {
     res[i] = {
@@ -449,7 +445,7 @@ function fromColumnar(cv: ColumnarVectors): Vector[] {
       vector: cv.vectors[i],
       attributes: cv.attributes
         ? Object.fromEntries(
-            attributeEntries.map(([key, values]) => [key, values[i]])
+            attributeEntries.map(([key, values]) => [key, values[i]]),
           )
         : undefined,
     };

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -173,7 +173,7 @@ export class Turbopuffer {
             }
           } catch (_: unknown) {}
         }
-        error = new TurbopufferError(message || response.statusText, {
+        error = new TurbopufferError(message ?? response.statusText, {
           status: response.status,
         });
       }
@@ -422,7 +422,7 @@ function toColumnar(vectors: Vector[]): ColumnarVectors {
   }
   const attributes: ColumnarAttributes = {};
   vectors.forEach((vec, i) => {
-    for (const [key, val] of Object.entries(vec.attributes || {})) {
+    for (const [key, val] of Object.entries(vec.attributes ?? {})) {
       if (!attributes[key]) {
         attributes[key] = new Array<AttributeType>(vectors.length).fill(null);
       }
@@ -438,7 +438,7 @@ function toColumnar(vectors: Vector[]): ColumnarVectors {
 
 function fromColumnar(cv: ColumnarVectors): Vector[] {
   const res = new Array<Vector>(cv.ids.length);
-  const attributeEntries = Object.entries(cv.attributes || {});
+  const attributeEntries = Object.entries(cv.attributes ?? {});
   for (let i = 0; i < cv.ids.length; i++) {
     res[i] = {
       id: cv.ids[i],

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -329,8 +329,8 @@ export class Namespace {
   async export(params?: {
     cursor?: string;
   }): Promise<{ vectors: Vector[]; next_cursor?: string }> {
-    type responseType = ColumnarVectors & { next_cursor: string };
-    const response = await this.client.doRequest<responseType>({
+    type ResponseType = ColumnarVectors & { next_cursor: string };
+    const response = await this.client.doRequest<ResponseType>({
       method: "GET",
       path: `/v1/vectors/${this.id}`,
       query: { cursor: params?.cursor },

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -351,7 +351,7 @@ export class Namespace {
    * Fetches the approximate number of vectors in a namespace.
    */
   async approxNumVectors(): Promise<number> {
-    const response = await this.client.doRequest<{}>({
+    const response = await this.client.doRequest<object>({
       method: "HEAD",
       path: `/v1/vectors/${this.id}`,
       retryable: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "declarationMap": true,
     "resolveJsonModule": true
   },
-  "include": ["src", "*.config.js"],
+  "include": ["src"],
   "exclude": ["src/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "target": "ES2017",
-        "module": "commonjs",
-        "moduleResolution": "Node",
-        "lib": ["es2017", "es2022", "es7", "es6", "dom"],
-        "strict": true,
-        "sourceMap": true,
-        "esModuleInterop": true,
-        "declaration": true,
-        "declarationMap": true,
-        "resolveJsonModule": true
-    },
-    "include": ["src"],
-    "exclude": ["src/*.test.ts"]
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "target": "ES2017",
+    "module": "commonjs",
+    "moduleResolution": "Node",
+    "lib": ["es2017", "es2022", "es7", "es6", "dom"],
+    "strict": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "*.config.js"],
+  "exclude": ["src/*.test.ts"]
 }


### PR DESCRIPTION
This PR runs the autofix for eslint and prettier. A few additional commits were made for the autofixable rules suggested by eslint plugins, which were not run with the `lint:fix` script (maybe there's a flag for this to enable, but probably not critical to figure out right now).

Child:
* https://github.com/turbopuffer/turbopuffer-typescript/pull/9

The whole stack (in order):
* https://github.com/turbopuffer/turbopuffer-typescript/pull/8 (this)
* https://github.com/turbopuffer/turbopuffer-typescript/pull/9
* https://github.com/turbopuffer/turbopuffer-typescript/pull/10
* https://github.com/turbopuffer/turbopuffer-typescript/pull/11