### PR TITLE
Etcd/move do request to file

### DIFF
--- a/src/createDoRequest.ts
+++ b/src/createDoRequest.ts
@@ -129,7 +129,7 @@ export const createDoRequest =
     };
   };
 
-/* Error type */
+/** An error class for errors returned by the turbopuffer API. */
 export class TurbopufferError extends Error {
   status?: number;
   constructor(
@@ -141,10 +141,12 @@ export class TurbopufferError extends Error {
   }
 }
 
+/** A helper function to determine if a status code should be retried. */
 function statusCodeShouldRetry(statusCode: number): boolean {
   return statusCode >= 500;
 }
 
+/** A helper function to delay for a given number of milliseconds. */
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/createDoRequest.ts
+++ b/src/createDoRequest.ts
@@ -11,6 +11,15 @@ export interface RequestParams {
 }
 export type RequestResponse<T> = Promise<{ body?: T; headers: Headers }>;
 
+/**
+ * This a curried helper function that returns a function for making fetch
+ * requests against the API.
+ *
+ * @param baseUrl The base URL of the API endpoint.
+ * @param apiKey The API key to use for authentication.
+ *
+ * @returns A function to make requests against the API.
+ */
 export const createDoRequest =
   <T>(baseUrl: string, apiKey: string) =>
   async ({

--- a/src/createDoRequest.ts
+++ b/src/createDoRequest.ts
@@ -1,0 +1,141 @@
+import pako from "pako";
+import { version } from "../package.json";
+
+export interface RequestParams {
+  method: string;
+  path: string;
+  query?: Record<string, string | undefined>;
+  body?: unknown;
+  compress?: boolean;
+  retryable?: boolean;
+}
+export type RequestResponse<T> = Promise<{ body?: T; headers: Headers }>;
+
+export const createDoRequest =
+  <T>(baseUrl: string, apiKey: string) =>
+  async ({
+    method,
+    path,
+    query,
+    body,
+    compress,
+    retryable,
+  }: RequestParams): RequestResponse<T> => {
+    const url = new URL(`${baseUrl}${path}`);
+    if (query) {
+      Object.keys(query).forEach((key) => {
+        const value = query[key];
+        if (value) {
+          url.searchParams.append(key, value);
+        }
+      });
+    }
+
+    const headers: Record<string, string> = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "Accept-Encoding": "gzip",
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      Authorization: `Bearer ${apiKey}`,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "User-Agent": `tpuf-typescript/${version}`,
+    };
+    if (body) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    let requestBody: BodyInit | null = null;
+    if (body && compress) {
+      headers["Content-Encoding"] = "gzip";
+      requestBody = pako.gzip(JSON.stringify(body));
+    } else if (body) {
+      requestBody = JSON.stringify(body);
+    }
+
+    const maxAttempts = retryable ? 3 : 1;
+    let response!: Response;
+    let error: TurbopufferError | null = null;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      response = await fetch(url.toString(), {
+        method,
+        headers,
+        body: requestBody,
+      });
+      if (response.status >= 400) {
+        let message: string | undefined = undefined;
+        if (response.headers.get("Content-Type") === "application/json") {
+          try {
+            const body = await response.json();
+            if (body && body.status === "error") {
+              message = body.error;
+            } else {
+              message = JSON.stringify(body);
+            }
+          } catch (_: unknown) {
+            /* empty */
+          }
+        } else {
+          try {
+            const body = await response.text();
+            if (body) {
+              message = body;
+            }
+          } catch (_: unknown) {
+            /* empty */
+          }
+        }
+        error = new TurbopufferError(message ?? response.statusText, {
+          status: response.status,
+        });
+      }
+      if (
+        error &&
+        statusCodeShouldRetry(response.status) &&
+        attempt + 1 != maxAttempts
+      ) {
+        await delay(150 * (attempt + 1)); // 150ms, 300ms, 450ms
+        continue;
+      }
+      break;
+    }
+    if (error) {
+      throw error;
+    }
+
+    if (!response.body) {
+      return {
+        headers: response.headers,
+      };
+    }
+
+    const json = await response.json();
+    if (json.status && json.status === "error") {
+      throw new TurbopufferError(json.error || (json as string), {
+        status: response.status,
+      });
+    }
+
+    return {
+      body: json as T,
+      headers: response.headers,
+    };
+  };
+
+/* Error type */
+export class TurbopufferError extends Error {
+  status?: number;
+  constructor(
+    public error: string,
+    { status }: { status?: number }
+  ) {
+    super(error);
+    this.status = status;
+  }
+}
+
+function statusCodeShouldRetry(statusCode: number): boolean {
+  return statusCode >= 500;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -5,9 +5,9 @@
  * Based off the initial work of https://github.com/holocron-hq! Thank you ❤️
  */
 
-import pako from "pako";
 import "isomorphic-fetch";
-import { version } from "../package.json";
+import type { RequestParams, RequestResponse } from "./createDoRequest";
+import { createDoRequest } from "./createDoRequest";
 
 /**
  * Utility Types
@@ -64,22 +64,11 @@ export interface RecallMeasurement {
   avg_ann_count: number;
 }
 
-/* Error type */
-export class TurbopufferError extends Error {
-  status?: number;
-  constructor(
-    public error: string,
-    { status }: { status?: number }
-  ) {
-    super(error);
-    this.status = status;
-  }
-}
-
 /* Base Client */
 export class Turbopuffer {
   private baseUrl: string;
   apiKey: string;
+  doRequest: <T>(_: RequestParams) => RequestResponse<T>;
 
   constructor({
     apiKey,
@@ -90,128 +79,8 @@ export class Turbopuffer {
   }) {
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
-  }
 
-  statusCodeShouldRetry(statusCode: number): boolean {
-    return statusCode >= 500;
-  }
-
-  delay(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
-  async doRequest<T>({
-    method,
-    path,
-    query,
-    body,
-    compress,
-    retryable,
-  }: {
-    method: string;
-    path: string;
-    query?: Record<string, string | undefined>;
-    body?: unknown;
-    compress?: boolean;
-    retryable?: boolean;
-  }): Promise<{ body?: T; headers: Headers }> {
-    const url = new URL(`${this.baseUrl}${path}`);
-    if (query) {
-      Object.keys(query).forEach((key) => {
-        const value = query[key];
-        if (value) {
-          url.searchParams.append(key, value);
-        }
-      });
-    }
-
-    const headers: Record<string, string> = {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      "Accept-Encoding": "gzip",
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      Authorization: `Bearer ${this.apiKey}`,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      "User-Agent": `tpuf-typescript/${version}`,
-    };
-    if (body) {
-      headers["Content-Type"] = "application/json";
-    }
-
-    let requestBody: BodyInit | null = null;
-    if (body && compress) {
-      headers["Content-Encoding"] = "gzip";
-      requestBody = pako.gzip(JSON.stringify(body));
-    } else if (body) {
-      requestBody = JSON.stringify(body);
-    }
-
-    const maxAttempts = retryable ? 3 : 1;
-    let response!: Response;
-    let error: TurbopufferError | null = null;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      response = await fetch(url.toString(), {
-        method,
-        headers,
-        body: requestBody,
-      });
-      if (response.status >= 400) {
-        let message: string | undefined = undefined;
-        if (response.headers.get("Content-Type") === "application/json") {
-          try {
-            const body = await response.json();
-            if (body && body.status === "error") {
-              message = body.error;
-            } else {
-              message = JSON.stringify(body);
-            }
-          } catch (_: unknown) {
-            /* empty */
-          }
-        } else {
-          try {
-            const body = await response.text();
-            if (body) {
-              message = body;
-            }
-          } catch (_: unknown) {
-            /* empty */
-          }
-        }
-        error = new TurbopufferError(message ?? response.statusText, {
-          status: response.status,
-        });
-      }
-      if (
-        error &&
-        this.statusCodeShouldRetry(response.status) &&
-        attempt + 1 != maxAttempts
-      ) {
-        await this.delay(150 * (attempt + 1)); // 150ms, 300ms, 450ms
-        continue;
-      }
-      break;
-    }
-    if (error) {
-      throw error;
-    }
-
-    if (!response.body) {
-      return {
-        headers: response.headers,
-      };
-    }
-
-    const json = await response.json();
-    if (json.status && json.status === "error") {
-      throw new TurbopufferError(json.error || (json as string), {
-        status: response.status,
-      });
-    }
-
-    return {
-      body: json as T,
-      headers: response.headers,
-    };
+    this.doRequest = createDoRequest(this.baseUrl, this.apiKey);
   }
 
   /**

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -8,6 +8,7 @@
 import "isomorphic-fetch";
 import type { RequestParams, RequestResponse } from "./createDoRequest";
 import { createDoRequest } from "./createDoRequest";
+export { TurbopufferError } from "./createDoRequest";
 
 /**
  * Utility Types


### PR DESCRIPTION
Moves the `doRequest` logic into a separate file. This will make it easier to extend the `doRequest` logic in the future, for adding things like runtime type-checking, without cluttering up the client code.

(This is a draft PR, stacked on top of a parent that currently needs to be merged first! The diff will be smaller once the parent is merged. The GitHub UI doesn't seem to let me change the diffbase, as the parent branch lives on my fork. Before merging, first merge the parent and rebase this PR on main.)

Parent:
* https://github.com/turbopuffer/turbopuffer-typescript/pull/8

Child:
* https://github.com/turbopuffer/turbopuffer-typescript/pull/10

The whole stack (in order):
* https://github.com/turbopuffer/turbopuffer-typescript/pull/8
* https://github.com/turbopuffer/turbopuffer-typescript/pull/9 (this)
* https://github.com/turbopuffer/turbopuffer-typescript/pull/10
* https://github.com/turbopuffer/turbopuffer-typescript/pull/11