### PR TITLE
Etcd/runtime typecheck with zod

### DIFF
--- a/jest_jsdom.config.js
+++ b/jest_jsdom.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
 };

--- a/jest_node.config.js
+++ b/jest_node.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
-  };
+  preset: "ts-jest",
+  testEnvironment: "node",
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbopuffer/turbopuffer",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0",
-        "pako": "^2.1.0"
+        "pako": "^2.1.0",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@types/isomorphic-fetch": "^0.0.39",
@@ -6800,6 +6801,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "isomorphic-fetch": "^3.0.0",
-    "pako": "^2.1.0"
+    "pako": "^2.1.0",
+    "zod": "^3.22.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --check . --ignore-path ./.gitignore",
     "format:fix": "prettier --check . --ignore-path ./.gitignore --write",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "typecheck": "tsc --noEmit"
   },
   "homepage": "https://turbopuffer.com",
   "repository": {

--- a/src/createDoRequest.ts
+++ b/src/createDoRequest.ts
@@ -129,7 +129,7 @@ export const createDoRequest =
     };
   };
 
-/* Error type */
+/** An error class for errors returned by the turbopuffer API. */
 export class TurbopufferError extends Error {
   status?: number;
   constructor(
@@ -141,10 +141,12 @@ export class TurbopufferError extends Error {
   }
 }
 
+/** A helper function to determine if a status code should be retried. */
 function statusCodeShouldRetry(statusCode: number): boolean {
   return statusCode >= 500;
 }
 
+/** A helper function to delay for a given number of milliseconds. */
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/createDoRequest.ts
+++ b/src/createDoRequest.ts
@@ -11,6 +11,15 @@ export interface RequestParams {
 }
 export type RequestResponse<T> = Promise<{ body?: T; headers: Headers }>;
 
+/**
+ * This a curried helper function that returns a function for making fetch
+ * requests against the API.
+ *
+ * @param baseUrl The base URL of the API endpoint.
+ * @param apiKey The API key to use for authentication.
+ *
+ * @returns A function to make requests against the API.
+ */
 export const createDoRequest =
   <T>(baseUrl: string, apiKey: string) =>
   async ({

--- a/src/createDoRequest.ts
+++ b/src/createDoRequest.ts
@@ -1,0 +1,141 @@
+import pako from "pako";
+import { version } from "../package.json";
+
+export interface RequestParams {
+  method: string;
+  path: string;
+  query?: Record<string, string | undefined>;
+  body?: unknown;
+  compress?: boolean;
+  retryable?: boolean;
+}
+export type RequestResponse<T> = Promise<{ body?: T; headers: Headers }>;
+
+export const createDoRequest =
+  <T>(baseUrl: string, apiKey: string) =>
+  async ({
+    method,
+    path,
+    query,
+    body,
+    compress,
+    retryable,
+  }: RequestParams): RequestResponse<T> => {
+    const url = new URL(`${baseUrl}${path}`);
+    if (query) {
+      Object.keys(query).forEach((key) => {
+        const value = query[key];
+        if (value) {
+          url.searchParams.append(key, value);
+        }
+      });
+    }
+
+    const headers: Record<string, string> = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "Accept-Encoding": "gzip",
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      Authorization: `Bearer ${apiKey}`,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "User-Agent": `tpuf-typescript/${version}`,
+    };
+    if (body) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    let requestBody: BodyInit | null = null;
+    if (body && compress) {
+      headers["Content-Encoding"] = "gzip";
+      requestBody = pako.gzip(JSON.stringify(body));
+    } else if (body) {
+      requestBody = JSON.stringify(body);
+    }
+
+    const maxAttempts = retryable ? 3 : 1;
+    let response!: Response;
+    let error: TurbopufferError | null = null;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      response = await fetch(url.toString(), {
+        method,
+        headers,
+        body: requestBody,
+      });
+      if (response.status >= 400) {
+        let message: string | undefined = undefined;
+        if (response.headers.get("Content-Type") === "application/json") {
+          try {
+            const body = await response.json();
+            if (body && body.status === "error") {
+              message = body.error;
+            } else {
+              message = JSON.stringify(body);
+            }
+          } catch (_: unknown) {
+            /* empty */
+          }
+        } else {
+          try {
+            const body = await response.text();
+            if (body) {
+              message = body;
+            }
+          } catch (_: unknown) {
+            /* empty */
+          }
+        }
+        error = new TurbopufferError(message ?? response.statusText, {
+          status: response.status,
+        });
+      }
+      if (
+        error &&
+        statusCodeShouldRetry(response.status) &&
+        attempt + 1 != maxAttempts
+      ) {
+        await delay(150 * (attempt + 1)); // 150ms, 300ms, 450ms
+        continue;
+      }
+      break;
+    }
+    if (error) {
+      throw error;
+    }
+
+    if (!response.body) {
+      return {
+        headers: response.headers,
+      };
+    }
+
+    const json = await response.json();
+    if (json.status && json.status === "error") {
+      throw new TurbopufferError(json.error || (json as string), {
+        status: response.status,
+      });
+    }
+
+    return {
+      body: json as T,
+      headers: response.headers,
+    };
+  };
+
+/* Error type */
+export class TurbopufferError extends Error {
+  status?: number;
+  constructor(
+    public error: string,
+    { status }: { status?: number }
+  ) {
+    super(error);
+    this.status = status;
+  }
+}
+
+function statusCodeShouldRetry(statusCode: number): boolean {
+  return statusCode >= 500;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,54 @@
+/**
+ * Utility Types
+ *
+ * Note: At the moment, negative numbers aren't supported.
+ */
+export type Id = string | number;
+export type AttributeType = null | string | number | string[] | number[];
+export type Attributes = Record<string, AttributeType>;
+export interface Vector {
+  id: Id;
+  vector?: number[];
+  attributes?: Attributes;
+}
+export type DistanceMetric = "cosine_distance" | "euclidean_squared";
+export type FilterOperator =
+  | "Eq"
+  | "NotEq"
+  | "In"
+  | "NotIn"
+  | "Lt"
+  | "Lte"
+  | "Gt"
+  | "Gte"
+  | "Glob"
+  | "NotGlob"
+  | "IGlob"
+  | "NotIGlob"
+  | "And"
+  | "Or";
+export type FilterConnective = "And" | "Or";
+export type FilterValue = Exclude<AttributeType, null>;
+export type FilterCondition = [string, FilterOperator, FilterValue];
+export type Filters = [FilterConnective, Filters[]] | FilterCondition;
+export type QueryResults = {
+  id: Id;
+  vector?: number[];
+  attributes?: Attributes;
+  dist?: number;
+}[];
+export interface NamespaceDesc {
+  id: string;
+  approx_count: number;
+  dimensions: number;
+  created_at: string; // RFC3339 format
+}
+export interface NamespacesListResult {
+  namespaces: NamespaceDesc[];
+  next_cursor?: string;
+}
+export interface RecallMeasurement {
+  avg_recall: number;
+  avg_exhaustive_count: number;
+  avg_ann_count: number;
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,16 +1,32 @@
+import { z } from "zod";
+
 /**
  * Utility Types
  *
  * Note: At the moment, negative numbers aren't supported.
  */
-export type Id = string | number;
-export type AttributeType = null | string | number | string[] | number[];
-export type Attributes = Record<string, AttributeType>;
-export interface Vector {
-  id: Id;
-  vector?: number[];
-  attributes?: Attributes;
-}
+export type Id = z.infer<typeof ID_SCHEMA>;
+export const ID_SCHEMA = z.union([z.string(), z.number()]);
+
+export type AttributeType = z.infer<typeof ATTRIBUTE_TYPE_SCHEMA>;
+export const ATTRIBUTE_TYPE_SCHEMA = z.union([
+  z.null(),
+  z.string(),
+  z.number(),
+  z.string().array(),
+  z.number().array(),
+]);
+
+export type Attributes = z.infer<typeof ATTRIBUTES_SCHEMA>;
+export const ATTRIBUTES_SCHEMA = z.record(z.string(), ATTRIBUTE_TYPE_SCHEMA);
+
+export type Vector = z.infer<typeof VECTOR_SCHEMA>;
+export const VECTOR_SCHEMA = z.object({
+  id: ID_SCHEMA,
+  vector: z.number().array().optional(),
+  attributes: ATTRIBUTES_SCHEMA.optional(),
+});
+
 export type DistanceMetric = "cosine_distance" | "euclidean_squared";
 export type FilterOperator =
   | "Eq"
@@ -31,24 +47,36 @@ export type FilterConnective = "And" | "Or";
 export type FilterValue = Exclude<AttributeType, null>;
 export type FilterCondition = [string, FilterOperator, FilterValue];
 export type Filters = [FilterConnective, Filters[]] | FilterCondition;
-export type QueryResults = {
-  id: Id;
-  vector?: number[];
-  attributes?: Attributes;
-  dist?: number;
-}[];
-export interface NamespaceDesc {
-  id: string;
-  approx_count: number;
-  dimensions: number;
-  created_at: string; // RFC3339 format
-}
-export interface NamespacesListResult {
-  namespaces: NamespaceDesc[];
-  next_cursor?: string;
-}
-export interface RecallMeasurement {
-  avg_recall: number;
-  avg_exhaustive_count: number;
-  avg_ann_count: number;
-}
+
+export type QueryResults = z.infer<typeof QUERY_RESULTS_SCHEMA>;
+export const QUERY_RESULTS_SCHEMA = z
+  .object({
+    id: ID_SCHEMA,
+    vector: z.number().array().optional(),
+    attributes: ATTRIBUTES_SCHEMA.optional(),
+    dist: z.number().optional(),
+  })
+  .array();
+
+export type NamespaceDesc = z.infer<typeof NAMESPACE_DESC_SCHEMA>;
+export const NAMESPACE_DESC_SCHEMA = z.object({
+  id: z.string(),
+  approx_count: z.number(),
+  dimensions: z.number(),
+  created_at: z.string(), // RFC3339 format
+});
+
+export type NamespacesListResult = z.infer<
+  typeof NAMESPACES_LIST_RESULT_SCHEMA
+>;
+export const NAMESPACES_LIST_RESULT_SCHEMA = z.object({
+  namespaces: NAMESPACE_DESC_SCHEMA.array(),
+  next_cursor: z.string().optional(),
+});
+
+export type RecallMeasurement = z.infer<typeof RECALL_MEASUREMENT_SCHEMA>;
+export const RECALL_MEASUREMENT_SCHEMA = z.object({
+  avg_recall: z.number(),
+  avg_exhaustive_count: z.number(),
+  avg_ann_count: z.number(),
+});

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -11,7 +11,9 @@ test("sanity", async () => {
 
   try {
     await ns.deleteAll();
-  } catch (_: unknown) {}
+  } catch (_: unknown) {
+    /* empty */
+  }
 
   await ns.upsert({
     vectors: [

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -1,7 +1,7 @@
 import { Turbopuffer } from "./turbopuffer";
 
 const tpuf = new Turbopuffer({
-  apiKey: process.env.TURBOPUFFER_API_KEY as string,
+  apiKey: process.env.TURBOPUFFER_API_KEY!,
 });
 
 test("sanity", async () => {
@@ -43,7 +43,7 @@ test("sanity", async () => {
   expect(results[0].id).toEqual(2);
   expect(results[1].id).toEqual(1);
 
-  let results2 = await ns.query({
+  const results2 = await ns.query({
     vector: [1, 1],
     filters: [
       "And",
@@ -69,7 +69,7 @@ test("sanity", async () => {
   expect(results2[0].id).toEqual(2);
   expect(results2[1].id).toEqual(1);
 
-  let recall = await ns.recall({
+  const recall = await ns.recall({
     num: 1,
     top_k: 2,
   });

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -11,7 +11,7 @@ test("sanity", async () => {
 
   try {
     await ns.deleteAll();
-  } catch (_: any) {}
+  } catch (_: unknown) {}
 
   await ns.upsert({
     vectors: [
@@ -98,7 +98,7 @@ test("sanity", async () => {
       vector: [1, 1],
       filters: ["numbers", "In", [2, 4]],
     });
-  } catch (_: any) {
+  } catch (_: unknown) {
     gotError = true;
   }
   expect(gotError).toBe(true);

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -69,7 +69,7 @@ export class TurbopufferError extends Error {
   status?: number;
   constructor(
     public error: string,
-    { status }: { status?: number },
+    { status }: { status?: number }
   ) {
     super(error);
     this.status = status;
@@ -111,7 +111,7 @@ export class Turbopuffer {
     method: string;
     path: string;
     query?: Record<string, string | undefined>;
-    body?: any;
+    body?: unknown;
     compress?: boolean;
     retryable?: boolean;
   }): Promise<{ body?: T; headers: Headers }> {
@@ -164,14 +164,14 @@ export class Turbopuffer {
             } else {
               message = JSON.stringify(body);
             }
-          } catch (_: any) {}
+          } catch (_: unknown) {}
         } else {
           try {
             const body = await response.text();
             if (body) {
               message = body;
             }
-          } catch (_: any) {}
+          } catch (_: unknown) {}
         }
         error = new TurbopufferError(message || response.statusText, {
           status: response.status,
@@ -445,7 +445,7 @@ function fromColumnar(cv: ColumnarVectors): Vector[] {
       vector: cv.vectors[i],
       attributes: cv.attributes
         ? Object.fromEntries(
-            attributeEntries.map(([key, values]) => [key, values[i]]),
+            attributeEntries.map(([key, values]) => [key, values[i]])
           )
         : undefined,
     };

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -5,9 +5,9 @@
  * Based off the initial work of https://github.com/holocron-hq! Thank you ❤️
  */
 
-import pako from "pako";
 import "isomorphic-fetch";
-import { version } from "../package.json";
+import type { RequestParams, RequestResponse } from "./createDoRequest";
+import { createDoRequest } from "./createDoRequest";
 
 /**
  * Utility Types
@@ -64,22 +64,11 @@ export interface RecallMeasurement {
   avg_ann_count: number;
 }
 
-/* Error type */
-export class TurbopufferError extends Error {
-  status?: number;
-  constructor(
-    public error: string,
-    { status }: { status?: number }
-  ) {
-    super(error);
-    this.status = status;
-  }
-}
-
 /* Base Client */
 export class Turbopuffer {
   private baseUrl: string;
   apiKey: string;
+  doRequest: <T>(_: RequestParams) => RequestResponse<T>;
 
   constructor({
     apiKey,
@@ -90,128 +79,8 @@ export class Turbopuffer {
   }) {
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
-  }
 
-  statusCodeShouldRetry(statusCode: number): boolean {
-    return statusCode >= 500;
-  }
-
-  delay(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
-  async doRequest<T>({
-    method,
-    path,
-    query,
-    body,
-    compress,
-    retryable,
-  }: {
-    method: string;
-    path: string;
-    query?: Record<string, string | undefined>;
-    body?: unknown;
-    compress?: boolean;
-    retryable?: boolean;
-  }): Promise<{ body?: T; headers: Headers }> {
-    const url = new URL(`${this.baseUrl}${path}`);
-    if (query) {
-      Object.keys(query).forEach((key) => {
-        const value = query[key];
-        if (value) {
-          url.searchParams.append(key, value);
-        }
-      });
-    }
-
-    const headers: Record<string, string> = {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      "Accept-Encoding": "gzip",
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      Authorization: `Bearer ${this.apiKey}`,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      "User-Agent": `tpuf-typescript/${version}`,
-    };
-    if (body) {
-      headers["Content-Type"] = "application/json";
-    }
-
-    let requestBody: BodyInit | null = null;
-    if (body && compress) {
-      headers["Content-Encoding"] = "gzip";
-      requestBody = pako.gzip(JSON.stringify(body));
-    } else if (body) {
-      requestBody = JSON.stringify(body);
-    }
-
-    const maxAttempts = retryable ? 3 : 1;
-    let response!: Response;
-    let error: TurbopufferError | null = null;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      response = await fetch(url.toString(), {
-        method,
-        headers,
-        body: requestBody,
-      });
-      if (response.status >= 400) {
-        let message: string | undefined = undefined;
-        if (response.headers.get("Content-Type") === "application/json") {
-          try {
-            const body = await response.json();
-            if (body && body.status === "error") {
-              message = body.error;
-            } else {
-              message = JSON.stringify(body);
-            }
-          } catch (_: unknown) {
-            /* empty */
-          }
-        } else {
-          try {
-            const body = await response.text();
-            if (body) {
-              message = body;
-            }
-          } catch (_: unknown) {
-            /* empty */
-          }
-        }
-        error = new TurbopufferError(message ?? response.statusText, {
-          status: response.status,
-        });
-      }
-      if (
-        error &&
-        this.statusCodeShouldRetry(response.status) &&
-        attempt + 1 != maxAttempts
-      ) {
-        await this.delay(150 * (attempt + 1)); // 150ms, 300ms, 450ms
-        continue;
-      }
-      break;
-    }
-    if (error) {
-      throw error;
-    }
-
-    if (!response.body) {
-      return {
-        headers: response.headers,
-      };
-    }
-
-    const json = await response.json();
-    if (json.status && json.status === "error") {
-      throw new TurbopufferError(json.error || (json as string), {
-        status: response.status,
-      });
-    }
-
-    return {
-      body: json as T,
-      headers: response.headers,
-    };
+    this.doRequest = createDoRequest(this.baseUrl, this.apiKey);
   }
 
   /**

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -164,14 +164,18 @@ export class Turbopuffer {
             } else {
               message = JSON.stringify(body);
             }
-          } catch (_: unknown) {}
+          } catch (_: unknown) {
+            /* empty */
+          }
         } else {
           try {
             const body = await response.text();
             if (body) {
               message = body;
             }
-          } catch (_: unknown) {}
+          } catch (_: unknown) {
+            /* empty */
+          }
         }
         error = new TurbopufferError(message ?? response.statusText, {
           status: response.status,

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -7,7 +7,7 @@
 
 import pako from "pako";
 import "isomorphic-fetch";
-import {version} from '../package.json';
+import { version } from "../package.json";
 
 /**
  * Utility Types
@@ -16,14 +16,12 @@ import {version} from '../package.json';
  */
 export type Id = string | number;
 export type AttributeType = null | string | number | string[] | number[];
-export type Attributes = {
-  [key: string]: AttributeType;
-};
-export type Vector = {
+export type Attributes = Record<string, AttributeType>;
+export interface Vector {
   id: Id;
   vector?: number[];
   attributes?: Attributes;
-};
+}
 export type DistanceMetric = "cosine_distance" | "euclidean_squared";
 export type FilterOperator =
   | "Eq"
@@ -50,28 +48,28 @@ export type QueryResults = {
   attributes?: Attributes;
   dist?: number;
 }[];
-export type NamespaceDesc = {
+export interface NamespaceDesc {
   id: string;
   approx_count: number;
   dimensions: number;
   created_at: string; // RFC3339 format
-};
-export type NamespacesListResult = {
+}
+export interface NamespacesListResult {
   namespaces: NamespaceDesc[];
   next_cursor?: string;
-};
-export type RecallMeasurement = {
+}
+export interface RecallMeasurement {
   avg_recall: number;
   avg_exhaustive_count: number;
   avg_ann_count: number;
-};
+}
 
 /* Error type */
 export class TurbopufferError extends Error {
   status?: number;
   constructor(
     public error: string,
-    { status }: { status?: number }
+    { status }: { status?: number },
   ) {
     super(error);
     this.status = status;
@@ -112,9 +110,7 @@ export class Turbopuffer {
   }: {
     method: string;
     path: string;
-    query?: {
-      [key: string]: string | undefined;
-    };
+    query?: Record<string, string | undefined>;
     body?: any;
     compress?: boolean;
     retryable?: boolean;
@@ -122,14 +118,14 @@ export class Turbopuffer {
     const url = new URL(`${this.baseUrl}${path}`);
     if (query) {
       Object.keys(query).forEach((key) => {
-        let value = query[key];
+        const value = query[key];
         if (value) {
           url.searchParams.append(key, value);
         }
       });
     }
 
-    let headers: Record<string, string> = {
+    const headers: Record<string, string> = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       "Accept-Encoding": "gzip",
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -150,8 +146,8 @@ export class Turbopuffer {
     }
 
     const maxAttempts = retryable ? 3 : 1;
-    var response!: Response;
-    var error: TurbopufferError | null = null;
+    let response!: Response;
+    let error: TurbopufferError | null = null;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       response = await fetch(url.toString(), {
         method,
@@ -162,7 +158,7 @@ export class Turbopuffer {
         let message: string | undefined = undefined;
         if (response.headers.get("Content-Type") === "application/json") {
           try {
-            let body = await response.json();
+            const body = await response.json();
             if (body && body.status === "error") {
               message = body.error;
             } else {
@@ -171,13 +167,15 @@ export class Turbopuffer {
           } catch (_: any) {}
         } else {
           try {
-            let body = await response.text();
+            const body = await response.text();
             if (body) {
               message = body;
             }
           } catch (_: any) {}
         }
-        error = new TurbopufferError(message || response.statusText, { status: response.status });
+        error = new TurbopufferError(message || response.statusText, {
+          status: response.status,
+        });
       }
       if (
         error &&
@@ -332,7 +330,7 @@ export class Namespace {
     cursor?: string;
   }): Promise<{ vectors: Vector[]; next_cursor?: string }> {
     type responseType = ColumnarVectors & { next_cursor: string };
-    let response = await this.client.doRequest<responseType>({
+    const response = await this.client.doRequest<responseType>({
       method: "GET",
       path: `/v1/vectors/${this.id}`,
       query: { cursor: params?.cursor },
@@ -349,12 +347,12 @@ export class Namespace {
    * Fetches the approximate number of vectors in a namespace.
    */
   async approxNumVectors(): Promise<number> {
-    let response = await this.client.doRequest<{}>({
+    const response = await this.client.doRequest<{}>({
       method: "HEAD",
       path: `/v1/vectors/${this.id}`,
       retryable: true,
     });
-    let num = response.headers.get("X-turbopuffer-Approx-Num-Vectors");
+    const num = response.headers.get("X-turbopuffer-Approx-Num-Vectors");
     return num ? parseInt(num) : 0;
   }
 
@@ -406,14 +404,12 @@ export class Namespace {
 
 /* Helpers */
 
-type ColumnarAttributes = {
-  [key: string]: AttributeType[];
-};
-type ColumnarVectors = {
+type ColumnarAttributes = Record<string, AttributeType[]>;
+interface ColumnarVectors {
   ids: Id[];
   vectors: number[][];
   attributes?: ColumnarAttributes;
-};
+}
 
 // Unused atm.
 function toColumnar(vectors: Vector[]): ColumnarVectors {
@@ -424,9 +420,9 @@ function toColumnar(vectors: Vector[]): ColumnarVectors {
       attributes: {},
     };
   }
-  let attributes: ColumnarAttributes = {};
+  const attributes: ColumnarAttributes = {};
   vectors.forEach((vec, i) => {
-    for (let [key, val] of Object.entries(vec.attributes || {})) {
+    for (const [key, val] of Object.entries(vec.attributes || {})) {
       if (!attributes[key]) {
         attributes[key] = new Array<AttributeType>(vectors.length).fill(null);
       }
@@ -441,7 +437,7 @@ function toColumnar(vectors: Vector[]): ColumnarVectors {
 }
 
 function fromColumnar(cv: ColumnarVectors): Vector[] {
-  let res = new Array<Vector>(cv.ids.length);
+  const res = new Array<Vector>(cv.ids.length);
   const attributeEntries = Object.entries(cv.attributes || {});
   for (let i = 0; i < cv.ids.length; i++) {
     res[i] = {
@@ -449,7 +445,7 @@ function fromColumnar(cv: ColumnarVectors): Vector[] {
       vector: cv.vectors[i],
       attributes: cv.attributes
         ? Object.fromEntries(
-            attributeEntries.map(([key, values]) => [key, values[i]])
+            attributeEntries.map(([key, values]) => [key, values[i]]),
           )
         : undefined,
     };

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -8,61 +8,16 @@
 import "isomorphic-fetch";
 import type { RequestParams, RequestResponse } from "./createDoRequest";
 import { createDoRequest } from "./createDoRequest";
-
-/**
- * Utility Types
- *
- * Note: At the moment, negative numbers aren't supported.
- */
-export type Id = string | number;
-export type AttributeType = null | string | number | string[] | number[];
-export type Attributes = Record<string, AttributeType>;
-export interface Vector {
-  id: Id;
-  vector?: number[];
-  attributes?: Attributes;
-}
-export type DistanceMetric = "cosine_distance" | "euclidean_squared";
-export type FilterOperator =
-  | "Eq"
-  | "NotEq"
-  | "In"
-  | "NotIn"
-  | "Lt"
-  | "Lte"
-  | "Gt"
-  | "Gte"
-  | "Glob"
-  | "NotGlob"
-  | "IGlob"
-  | "NotIGlob"
-  | "And"
-  | "Or";
-export type FilterConnective = "And" | "Or";
-export type FilterValue = Exclude<AttributeType, null>;
-export type FilterCondition = [string, FilterOperator, FilterValue];
-export type Filters = [FilterConnective, Filters[]] | FilterCondition;
-export type QueryResults = {
-  id: Id;
-  vector?: number[];
-  attributes?: Attributes;
-  dist?: number;
-}[];
-export interface NamespaceDesc {
-  id: string;
-  approx_count: number;
-  dimensions: number;
-  created_at: string; // RFC3339 format
-}
-export interface NamespacesListResult {
-  namespaces: NamespaceDesc[];
-  next_cursor?: string;
-}
-export interface RecallMeasurement {
-  avg_recall: number;
-  avg_exhaustive_count: number;
-  avg_ann_count: number;
-}
+import type {
+  AttributeType,
+  DistanceMetric,
+  Filters,
+  Id,
+  NamespacesListResult,
+  QueryResults,
+  RecallMeasurement,
+  Vector,
+} from "./schemas";
 
 /* Base Client */
 export class Turbopuffer {

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -173,7 +173,7 @@ export class Turbopuffer {
             }
           } catch (_: unknown) {}
         }
-        error = new TurbopufferError(message || response.statusText, {
+        error = new TurbopufferError(message ?? response.statusText, {
           status: response.status,
         });
       }
@@ -422,7 +422,7 @@ function toColumnar(vectors: Vector[]): ColumnarVectors {
   }
   const attributes: ColumnarAttributes = {};
   vectors.forEach((vec, i) => {
-    for (const [key, val] of Object.entries(vec.attributes || {})) {
+    for (const [key, val] of Object.entries(vec.attributes ?? {})) {
       if (!attributes[key]) {
         attributes[key] = new Array<AttributeType>(vectors.length).fill(null);
       }
@@ -438,7 +438,7 @@ function toColumnar(vectors: Vector[]): ColumnarVectors {
 
 function fromColumnar(cv: ColumnarVectors): Vector[] {
   const res = new Array<Vector>(cv.ids.length);
-  const attributeEntries = Object.entries(cv.attributes || {});
+  const attributeEntries = Object.entries(cv.attributes ?? {});
   for (let i = 0; i < cv.ids.length; i++) {
     res[i] = {
       id: cv.ids[i],

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -329,8 +329,8 @@ export class Namespace {
   async export(params?: {
     cursor?: string;
   }): Promise<{ vectors: Vector[]; next_cursor?: string }> {
-    type responseType = ColumnarVectors & { next_cursor: string };
-    const response = await this.client.doRequest<responseType>({
+    type ResponseType = ColumnarVectors & { next_cursor: string };
+    const response = await this.client.doRequest<ResponseType>({
       method: "GET",
       path: `/v1/vectors/${this.id}`,
       query: { cursor: params?.cursor },

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -351,7 +351,7 @@ export class Namespace {
    * Fetches the approximate number of vectors in a namespace.
    */
   async approxNumVectors(): Promise<number> {
-    const response = await this.client.doRequest<{}>({
+    const response = await this.client.doRequest<object>({
       method: "HEAD",
       path: `/v1/vectors/${this.id}`,
       retryable: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "declarationMap": true,
     "resolveJsonModule": true
   },
-  "include": ["src", "*.config.js"],
+  "include": ["src"],
   "exclude": ["src/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-        "target": "ES2017",
-        "module": "commonjs",
-        "moduleResolution": "Node",
-        "lib": ["es2017", "es2022", "es7", "es6", "dom"],
-        "strict": true,
-        "sourceMap": true,
-        "esModuleInterop": true,
-        "declaration": true,
-        "declarationMap": true,
-        "resolveJsonModule": true
-    },
-    "include": ["src"],
-    "exclude": ["src/*.test.ts"]
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "target": "ES2017",
+    "module": "commonjs",
+    "moduleResolution": "Node",
+    "lib": ["es2017", "es2022", "es7", "es6", "dom"],
+    "strict": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "*.config.js"],
+  "exclude": ["src/*.test.ts"]
 }


### PR DESCRIPTION
Adds zod schemas for all response types. Extends request logic to typecheck responses.

(This is a draft PR, stacked on top of a parent that currently needs to be merged first! The diff will be smaller once the parent is merged. The GitHub UI doesn't seem to let me change the diffbase, as the parent branch lives on my fork. Before merging, first merge the parent and rebase this PR on main.)

Parent:
* https://github.com/turbopuffer/turbopuffer-typescript/pull/10

The whole stack (in order):
* https://github.com/turbopuffer/turbopuffer-typescript/pull/8
* https://github.com/turbopuffer/turbopuffer-typescript/pull/9
* https://github.com/turbopuffer/turbopuffer-typescript/pull/10
* https://github.com/turbopuffer/turbopuffer-typescript/pull/11 (this)