### PR TITLE
wrap generic "fetch failed" error and retry

### DIFF
--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -71,17 +71,20 @@ export class Turbopuffer {
   constructor({
     apiKey,
     baseUrl = "https://api.turbopuffer.com",
+    connectTimeout = 10 * 1000, // timeout to establish a connection
     connectionIdleTimeout = 60 * 1000, // socket idle timeout in ms, default 1 minute
     warmConnections = 0, // number of connections to open initially when creating a new client
   }: {
     apiKey: string;
     baseUrl?: string;
+    connectTimeout?: number;
     connectionIdleTimeout?: number;
     warmConnections?: number;
   }) {
     this.http = createHTTPClient(
       baseUrl,
       apiKey,
+      connectTimeout,
       connectionIdleTimeout,
       warmConnections,
     );


### PR DESCRIPTION
whenever any kind of network error occurs, undici throws a TypeError with a generic "fetch failed" message

https://github.com/nodejs/undici/blob/9458ffd4f1e5116cdcf8b421a3171d3aded41d46/lib/web/fetch/index.js#L223-L228

this:
1. is confusing for end users
2. doesn't currently get retried

this PR wraps such errors (and any thrown by fetch) in a TurbopufferError and retries according to the existing retry rules

see the new test for an example error message