### PR TITLE
Add response_time and body_read_time metrics

### DIFF
--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -50,6 +50,8 @@ test("sanity", async () => {
   expect(metrics.approx_namespace_size).toEqual(2);
   expect(metrics.exhaustive_search_count).toEqual(2);
   expect(metrics.processing_time).toBeGreaterThan(10);
+  expect(metrics.response_time).toBeGreaterThan(10);
+  expect(metrics.body_read_time).toBeGreaterThan(0);
 
   const results2 = await ns.query({
     vector: [1, 1],

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -56,6 +56,8 @@ export type QueryMetrics = {
   cache_temperature: string;
   processing_time: number;
   exhaustive_search_count: number;
+  response_time: number;
+  body_read_time: number;
 };
 
 export interface NamespaceMetadata {
@@ -271,6 +273,8 @@ export class Namespace {
         exhaustive_search_count: parseIntMetric(
           serverTiming["exhaustive_search.count"],
         ),
+        response_time: response.request_timing.response_time,
+        body_read_time: response.request_timing.body_read_time,
       },
     };
   }


### PR DESCRIPTION
This will help determine the source of latency. 

With a test that queries 2 rows that each have ~64k of attributes, the metrics object looks like this:

```
    {
      approx_namespace_size: 2,
      cache_hit_ratio: 1,
      cache_temperature: 'hot',
      processing_time: 56,
      exhaustive_search_count: 2,
      response_time: 92.14187500000003,
      body_read_time: 66.29495799999995
    }
```

The latency from my laptop to us-central is 30ms, so it makes sense that 56ms of processing time + 30ms is around 90ms. Then it seems an additional 2 roundtrips worth of latency happen to finish reading the body.