### PR TITLE
compress query response body

### DIFF
--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -267,6 +267,7 @@ export class Namespace {
       path: `/v1/vectors/${this.id}/query`,
       body: params,
       retryable: true,
+      compress: true,
     });
 
     const serverTimingStr = response.headers.get("Server-Timing");


### PR DESCRIPTION
I don't see any reason not to compress, reduces a 20kB query with a 1536 dimension vector and some filters to 8kB.