### PR TITLE
add deserialize_time metric and fix body_read_time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.5.4",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbopuffer/turbopuffer",
-      "version": "0.5.4",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Official Typescript API client library for turbopuffer.com",
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -178,6 +178,7 @@ test("sanity", async () => {
   expect(metrics.processing_time).toBeGreaterThan(10);
   expect(metrics.response_time).toBeGreaterThan(10);
   expect(metrics.body_read_time).toBeGreaterThan(0);
+  expect(metrics.deserialize_time).toBeGreaterThan(0);
 
   const results2 = await ns.query({
     vector: [1, 1],

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -70,6 +70,7 @@ export interface QueryMetrics {
   exhaustive_search_count: number;
   response_time: number;
   body_read_time: number;
+  deserialize_time: number;
 }
 
 export interface NamespaceMetadata {
@@ -293,6 +294,7 @@ export class Namespace {
         ),
         response_time: response.request_timing.response_time,
         body_read_time: response.request_timing.body_read_time,
+        deserialize_time: response.request_timing.deserialize_time,
       },
     };
   }
@@ -431,8 +433,8 @@ function fromColumnar(cv: ColumnarVectors): Vector[] {
       vector: cv.vectors[i],
       attributes: cv.attributes
         ? Object.fromEntries(
-          attributeEntries.map(([key, values]) => [key, values[i]]),
-        )
+            attributeEntries.map(([key, values]) => [key, values[i]]),
+          )
         : undefined,
     };
   }


### PR DESCRIPTION
avoids lumping these two parts of response processing together