### PR TITLE
use undici.request for httpClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbopuffer/turbopuffer",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0",
-        "undici": "^6.13.0"
+        "undici": "^6.19.8"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -5993,11 +5993,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.13.0.tgz",
-      "integrity": "sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "license": "MIT",
       "engines": {
-        "node": ">=18.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   },
   "dependencies": {
     "pako": "^2.1.0",
-    "undici": "^6.13.0"
+    "undici": "^6.19.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Official Typescript API client library for turbopuffer.com",
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -175,10 +175,10 @@ class DefaultHTTPClient implements HTTPClient {
 
       if (!error && response.statusCode >= 400) {
         let message: string | undefined = undefined;
-        let { body_text } = await consumeResponseText(response);
+        const { body_text } = await consumeResponseText(response);
         if (response.headers["content-type"] === "application/json") {
           try {
-            const body = JSON.parse(body_text) as any;
+            const body = JSON.parse(body_text);
             if (body && body.status === "error") {
               message = body.error;
             } else {
@@ -218,7 +218,7 @@ class DefaultHTTPClient implements HTTPClient {
       };
     }
 
-    let { body_text, body_read_end, decompress_end } =
+    const { body_text, body_read_end, decompress_end } =
       await consumeResponseText(response);
 
     const json = JSON.parse(body_text);
@@ -303,16 +303,16 @@ async function consumeResponseText(response: Dispatcher.ResponseData): Promise<{
   decompress_end: number;
 }> {
   if (response.headers["content-encoding"] == "gzip") {
-    let body_buffer = await response.body.arrayBuffer();
-    let body_read_end = performance.now();
+    const body_buffer = await response.body.arrayBuffer();
+    const body_read_end = performance.now();
 
-    let gunzip_buffer = await gunzipAsync(body_buffer);
-    let body_text = gunzip_buffer.toString(); // is there a better way?
-    let decompress_end = performance.now();
+    const gunzip_buffer = await gunzipAsync(body_buffer);
+    const body_text = gunzip_buffer.toString(); // is there a better way?
+    const decompress_end = performance.now();
     return { body_text, body_read_end, decompress_end };
   } else {
-    let body_text = await response.body.text();
-    let body_read_end = performance.now();
+    const body_text = await response.body.text();
+    const body_read_end = performance.now();
     return { body_text, body_read_end, decompress_end: body_read_end };
   }
 }

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -178,6 +178,7 @@ test("sanity", async () => {
   expect(metrics.processing_time).toBeGreaterThan(10);
   expect(metrics.response_time).toBeGreaterThan(10);
   expect(metrics.body_read_time).toBeGreaterThan(0);
+  expect(metrics.decompress_time).toEqual(0); // response was too small to compress
   expect(metrics.deserialize_time).toBeGreaterThan(0);
 
   const results2 = await ns.query({

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -71,6 +71,7 @@ export interface QueryMetrics {
   response_time: number;
   body_read_time: number;
   deserialize_time: number;
+  decompress_time: number;
 }
 
 export interface NamespaceMetadata {
@@ -294,6 +295,7 @@ export class Namespace {
         ),
         response_time: response.request_timing.response_time,
         body_read_time: response.request_timing.body_read_time,
+        decompress_time: response.request_timing.decompress_time,
         deserialize_time: response.request_timing.deserialize_time,
       },
     };

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -275,7 +275,7 @@ export class Namespace {
       compress: true,
     });
 
-    const serverTimingStr = response.headers.get("Server-Timing");
+    const serverTimingStr = response.headers["server-timing"];
     const serverTiming = serverTimingStr
       ? parseServerTiming(serverTimingStr)
       : {};
@@ -284,7 +284,7 @@ export class Namespace {
       results: response.body!,
       metrics: {
         approx_namespace_size: parseIntMetric(
-          response.headers.get("X-turbopuffer-Approx-Namespace-Size"),
+          response.headers["x-turbopuffer-approx-namespace-size"],
         ),
         cache_hit_ratio: parseFloatMetric(serverTiming["cache.hit_ratio"]),
         cache_temperature: serverTiming["cache.temperature"],
@@ -337,10 +337,10 @@ export class Namespace {
     return {
       id: this.id,
       approx_count: parseInt(
-        response.headers.get("X-turbopuffer-Approx-Num-Vectors")!,
+        response.headers["x-turbopuffer-approx-num-vectors"]!,
       ),
-      dimensions: parseInt(response.headers.get("X-turbopuffer-Dimensions")!),
-      created_at: new Date(response.headers.get("X-turbopuffer-Created-At")!),
+      dimensions: parseInt(response.headers["x-turbopuffer-dimensions"]!),
+      created_at: new Date(response.headers["x-turbopuffer-created-at"]!),
     };
   }
 


### PR DESCRIPTION
according to the undici docs this method is much faster than fetch https://github.com/nodejs/undici/tree/main#benchmarks

my preliminary performance testing agrees with this, notably better combined body_read_time+deserialize_time when the process is under load

this is passing tests and should work, but could use:

- [x] test that gunzip actually works (the test suite responses are too small to trigger it)
- [ ] stream gunzip? edit: decided not to
    - advantages of streamed gunzip:
        - in theory it's better to pipeline the cpu work with the io
    - advantages of oneshot gunzip:
        - can time the body read and gunzip separately
        - maybe drive i/o faster to buffer the whole response sooner
        - fewer context switches to C
- [x] separate metric for gunzip / json?
- [x] reduce lint errors