### PR TITLE
http: allow disabling compression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.29.1",
         "jest": "^29.7.0",
-        "prettier": "^3.2.5",
+        "prettier": "^3.3.3",
         "ts-jest": "^29.1.2",
         "typescript": "^5.4.3"
       }
@@ -5149,9 +5149,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
     "jest": "^29.7.0",
-    "prettier": "^3.2.5",
+    "prettier": "^3.3.3",
     "ts-jest": "^29.1.2",
     "typescript": "^5.4.3"
   },

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -16,12 +16,13 @@ export interface RequestParams {
   retryable?: boolean;
 }
 
-export type RequestTiming = {
+export interface RequestTiming {
   response_time: number;
   body_read_time: number;
   decompress_time: number;
+  compress_time: number;
   deserialize_time: number;
-};
+}
 
 export type RequestResponse<T> = Promise<{
   body?: T;
@@ -48,6 +49,7 @@ export const createHTTPClient = (
   connectTimeout: number,
   idleTimeout: number,
   warmConnections: number,
+  compression: boolean,
 ) =>
   new DefaultHTTPClient(
     baseUrl,
@@ -55,6 +57,7 @@ export const createHTTPClient = (
     connectTimeout,
     idleTimeout,
     warmConnections,
+    compression,
   );
 
 class DefaultHTTPClient implements HTTPClient {
@@ -63,6 +66,7 @@ class DefaultHTTPClient implements HTTPClient {
   private origin: URL;
   private apiKey: string;
   readonly userAgent = `tpuf-typescript/${version}`;
+  private compression: boolean;
 
   constructor(
     baseUrl: string,
@@ -70,11 +74,13 @@ class DefaultHTTPClient implements HTTPClient {
     connectTimeout: number,
     idleTimeout: number,
     warmConnections: number,
+    compression: boolean,
   ) {
     this.baseUrl = baseUrl;
     this.origin = new URL(baseUrl);
     this.origin.pathname = "";
     this.apiKey = apiKey;
+    this.compression = compression;
 
     this.agent = new Agent({
       keepAliveTimeout: idleTimeout, // how long a socket can be idle for before it is closed
@@ -118,20 +124,26 @@ class DefaultHTTPClient implements HTTPClient {
 
     const headers: Record<string, string> = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      "Accept-Encoding": "gzip",
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       Authorization: `Bearer ${this.apiKey}`,
       // eslint-disable-next-line @typescript-eslint/naming-convention
       "User-Agent": this.userAgent,
     };
+
+    if (this.compression) {
+      headers["Accept-Encoding"] = "gzip";
+    }
+
     if (body) {
       headers["Content-Type"] = "application/json";
     }
 
+    let requestCompressionDuration;
     let requestBody: Uint8Array | string | null = null;
-    if (body && compress) {
+    if (body && compress && this.compression) {
       headers["Content-Encoding"] = "gzip";
+      const beforeRequestCmpression = performance.now();
       requestBody = await gzipAsync(JSON.stringify(body));
+      requestCompressionDuration = performance.now() - beforeRequestCmpression;
     } else if (body) {
       requestBody = JSON.stringify(body);
     }
@@ -152,7 +164,7 @@ class DefaultHTTPClient implements HTTPClient {
           method: method as Dispatcher.HttpMethod,
           headers,
           body: requestBody,
-        })!;
+        });
       } catch (e: unknown) {
         if (e instanceof Error) {
           if (e.cause instanceof Error) {
@@ -239,6 +251,7 @@ class DefaultHTTPClient implements HTTPClient {
         body_read_end,
         decompress_end,
         deserialize_end,
+        requestCompressionDuration,
       ),
     };
   }
@@ -272,10 +285,12 @@ function make_request_timing(
   body_read_end?: number,
   decompress_end?: number,
   deserialize_end?: number,
+  requestCompressionDuration?: number,
 ): RequestTiming {
   return {
     response_time: response_start - request_start,
     body_read_time: body_read_end ? body_read_end - response_start : 0,
+    compress_time: requestCompressionDuration ? requestCompressionDuration : 0,
     decompress_time:
       decompress_end && body_read_end ? decompress_end - body_read_end : 0,
     deserialize_time:

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -141,9 +141,9 @@ class DefaultHTTPClient implements HTTPClient {
     let requestBody: Uint8Array | string | null = null;
     if (body && compress && this.compression) {
       headers["Content-Encoding"] = "gzip";
-      const beforeRequestCmpression = performance.now();
+      const beforeRequestCompression = performance.now();
       requestBody = await gzipAsync(JSON.stringify(body));
-      requestCompressionDuration = performance.now() - beforeRequestCmpression;
+      requestCompressionDuration = performance.now() - beforeRequestCompression;
     } else if (body) {
       requestBody = JSON.stringify(body);
     }

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -328,7 +328,7 @@ test("compression", async () => {
   }
 
   // Insert a large number of vectors to trigger compression
-  const vectors = Array.from({ length: 100 }, (_, i) => ({
+  const vectors = Array.from({ length: 10 }, (_, i) => ({
     id: i + 1,
     vector: randomVector(1024),
     attributes: {
@@ -372,7 +372,7 @@ test("disable_compression", async () => {
   }
 
   // Insert a large number of vectors to trigger compression
-  const vectors = Array.from({ length: 100 }, (_, i) => ({
+  const vectors = Array.from({ length: 10 }, (_, i) => ({
     id: i + 1,
     vector: randomVector(1024),
     attributes: {

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -179,6 +179,7 @@ test("sanity", async () => {
   expect(metrics.response_time).toBeGreaterThan(10);
   expect(metrics.body_read_time).toBeGreaterThan(0);
   expect(metrics.decompress_time).toEqual(0); // response was too small to compress
+  expect(metrics.compress_time).toBeGreaterThan(0);
   expect(metrics.deserialize_time).toBeGreaterThan(0);
 
   const results2 = await ns.query({

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -124,12 +124,14 @@ export class Turbopuffer {
     connectTimeout = 10 * 1000, // timeout to establish a connection
     connectionIdleTimeout = 60 * 1000, // socket idle timeout in ms, default 1 minute
     warmConnections = 0, // number of connections to open initially when creating a new client
+    compression = true,
   }: {
     apiKey: string;
     baseUrl?: string;
     connectTimeout?: number;
     connectionIdleTimeout?: number;
     warmConnections?: number;
+    compression?: boolean;
   }) {
     this.http = createHTTPClient(
       baseUrl,
@@ -137,6 +139,7 @@ export class Turbopuffer {
       connectTimeout,
       connectionIdleTimeout,
       warmConnections,
+      compression,
     );
   }
 
@@ -339,10 +342,10 @@ export class Namespace {
     return {
       id: this.id,
       approx_count: parseInt(
-        response.headers["x-turbopuffer-approx-num-vectors"]!,
+        response.headers["x-turbopuffer-approx-num-vectors"],
       ),
-      dimensions: parseInt(response.headers["x-turbopuffer-dimensions"]!),
-      created_at: new Date(response.headers["x-turbopuffer-created-at"]!),
+      dimensions: parseInt(response.headers["x-turbopuffer-dimensions"]),
+      created_at: new Date(response.headers["x-turbopuffer-created-at"]),
     };
   }
 
@@ -435,8 +438,8 @@ function fromColumnar(cv: ColumnarVectors): Vector[] {
       vector: cv.vectors[i],
       attributes: cv.attributes
         ? Object.fromEntries(
-            attributeEntries.map(([key, values]) => [key, values[i]]),
-          )
+          attributeEntries.map(([key, values]) => [key, values[i]]),
+        )
         : undefined,
     };
   }

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -440,8 +440,8 @@ function fromColumnar(cv: ColumnarVectors): Vector[] {
       vector: cv.vectors[i],
       attributes: cv.attributes
         ? Object.fromEntries(
-          attributeEntries.map(([key, values]) => [key, values[i]]),
-        )
+            attributeEntries.map(([key, values]) => [key, values[i]]),
+          )
         : undefined,
     };
   }

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -72,6 +72,7 @@ export interface QueryMetrics {
   body_read_time: number;
   deserialize_time: number;
   decompress_time: number;
+  compress_time: number;
 }
 
 export interface NamespaceMetadata {
@@ -300,6 +301,7 @@ export class Namespace {
         body_read_time: response.request_timing.body_read_time,
         decompress_time: response.request_timing.decompress_time,
         deserialize_time: response.request_timing.deserialize_time,
+        compress_time: response.request_timing.compress_time,
       },
     };
   }


### PR DESCRIPTION
In cases with very fast, underutilized networks, CPU may be a more sparse. In those cases, it can be advisable to disable compression.

@pushrax 