### PR TITLE
Enumerate acceptable values on schema `type` field

### DIFF
--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -1,5 +1,6 @@
 import { Turbopuffer } from "./turbopuffer";
 import { isRuntimeFullyNodeCompatible, TurbopufferError } from "./helpers";
+import { Schema } from "./types";
 
 const tpuf = new Turbopuffer({
   apiKey: process.env.TURBOPUFFER_API_KEY!,
@@ -18,9 +19,9 @@ test("bm25_with_custom_schema_and_sum_query", async () => {
     /* empty */
   }
 
-  const schema = {
+  const schema: Schema = {
     text: {
-      type: "?string",
+      type: "string",
       bm25: {
         language: "english",
         stemming: true,
@@ -168,9 +169,9 @@ test("bm25_with_default_schema_and_simple_query", async () => {
     /* empty */
   }
 
-  const schema = {
+  const schema: Schema = {
     text: {
-      type: "?string",
+      type: "string",
       bm25: true,
     },
   };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,12 +18,13 @@ export interface FTSParams {
   case_sensitive: boolean;
   tokenizer: string;
 }
+export type SchemaType = "string" | "uint" | "uuid" | "bool" | "[]string" | "[]uint" | "[]uuid";
 // TODO: index signature is a better fit here imo.
 // also look into eslint config to allow for usage of index signatures
 export type Schema = Record<
   string,
   {
-    type?: string;
+    type?: SchemaType;
     filterable?: boolean;
     bm25?: boolean | Partial<FTSParams>;
     full_text_search?: boolean | Partial<FTSParams>;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,7 +18,7 @@ export interface FTSParams {
   case_sensitive: boolean;
   tokenizer: string;
 }
-export type SchemaType = "string" | "uint" | "uuid" | "bool" | "[]string" | "[]uint" | "[]uuid";
+export type SchemaType = "string" | "int" | "uint" | "uuid" | "bool" | "[]string" | "[]int" | "[]uint" | "[]uuid";
 // TODO: index signature is a better fit here imo.
 // also look into eslint config to allow for usage of index signatures
 export type Schema = Record<


### PR DESCRIPTION
To help users avoid typos in their schema definitions (e.g., `boolean` instead of `bool`, or `integer` instead of `uint`).