### PR TITLE
Fix type exports: Re-export types in main module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbopuffer/turbopuffer",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Official Typescript API client library for turbopuffer.com",
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -354,3 +354,6 @@ export class Namespace {
     ).body!;
   }
 }
+
+// Re-export all types in types.ts for consumers
+export * from './types';


### PR DESCRIPTION
Currently, if the main module (turbopuffer.ts) does not export a type, end-users cannot import them directly from @turbopuffer/turbopuffer; instead they'll have to import from @turbopuffer/turbopuffer/dist/types which is not very DX-friendly:
```ts
import { Turbopuffer } from "@turbopuffer/turbopuffer"
import { Vector } from "@turbopuffer/turbopuffer/dist/types"
```

Re-exporting all types in types.ts in the main module makes this nicer:
```ts
import { Turbopuffer, Vector } from "@turbopuffer/turbopuffer"
```