### PR TITLE
Make .namespaces() obj arg optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbopuffer/turbopuffer",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Official Typescript API client library for turbopuffer.com",
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -76,7 +76,7 @@ export class Turbopuffer {
     cursor?: string;
     prefix?: string;
     page_size?: number;
-  }): Promise<NamespacesListResult> {
+  } = {}): Promise<NamespacesListResult> {
     return (
       await this.http.doRequest<NamespacesListResult>({
         method: "GET",


### PR DESCRIPTION
Currently, you have to do:
```ts
await tpuf.namespaces({});
```

If we're not passing any of the obj arg fields, just doing the following should work (I think this is nicer and also matches the python client):
```ts
await tpuf.namespaces();
```