### PR TITLE
Fix url path building

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Usage:
 // We recommend creating a single instance and reusing it for all calls
 const tpuf = new Turbopuffer({
   apiKey: process.env.TURBOPUFFER_API_KEY as string,
+  // see https://turbopuffer.com/docs/regions for available regions
+  baseUrl: "https://gcp-us-east4.turbopuffer.com",
 });
 
 // Instantiate an object to work with a namespace

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbopuffer/turbopuffer",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Official Typescript API client library for turbopuffer.com",
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/src/httpClient/default.ts
+++ b/src/httpClient/default.ts
@@ -58,7 +58,7 @@ export default class DefaultHTTPClient implements HTTPClient {
     compress,
     retryable,
   }: RequestParams): RequestResponse<T> {
-    const url = new URL(`${this.baseUrl}${path}`);
+    const url = new URL(path, this.baseUrl);
     if (query) {
       Object.keys(query).forEach((key) => {
         const value = query[key];

--- a/src/httpClient/default.ts
+++ b/src/httpClient/default.ts
@@ -69,7 +69,7 @@ export default class DefaultHTTPClient implements HTTPClient {
     }
     path = url.pathname;
     if (query) {
-      path += "?" + url.search;
+      path += url.search;
     }
 
     const headers: Record<string, string> = {

--- a/src/httpClient/node.ts
+++ b/src/httpClient/node.ts
@@ -111,7 +111,7 @@ export default class NodeHTTPClient implements HTTPClient {
     }
     path = url.pathname;
     if (query) {
-      path += "?" + url.search;
+      path += url.search;
     }
 
     const headers: Record<string, string> = {

--- a/src/httpClient/node.ts
+++ b/src/httpClient/node.ts
@@ -100,7 +100,7 @@ export default class NodeHTTPClient implements HTTPClient {
     compress,
     retryable,
   }: RequestParams): RequestResponse<T> {
-    const url = new URL(`${this.baseUrl}${path}`);
+    const url = new URL(path, this.baseUrl);
     if (query) {
       Object.keys(query).forEach((key) => {
         const value = query[key];

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -7,13 +7,13 @@ const tpuf = new Turbopuffer({
 
 const testNamespacePrefix = "typescript_sdk_";
 
-test("trailing_slashes_in_url", async () => {
+test("trailing_slashes_in_base_url", async () => {
   const tpuf = new Turbopuffer({
     apiKey: process.env.TURBOPUFFER_API_KEY!,
-    baseUrl: "https://gcp-us-east4.turbopuffer.com/",
+    baseUrl: "https://gcp-us-east4.turbopuffer.com//",
   });
 
-  const ns = tpuf.namespace(testNamespacePrefix + "trailing_slashes_in_url");
+  const ns = tpuf.namespace(testNamespacePrefix + "trailing_slashes_in_base_url");
 
   await ns.upsert({
     vectors: [

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -245,6 +245,21 @@ test("bm25_with_default_schema_and_simple_query", async () => {
   expect(results[0].id).toEqual(2);
 });
 
+test("namespaces", async () => {
+  const namespaces0 = await tpuf.namespaces({ page_size: 5 });
+  const cursor0 = namespaces0.next_cursor;
+
+  const namespaces1 = await tpuf.namespaces({
+    cursor: cursor0,
+    page_size: 5,
+  });
+  const cursor1 = namespaces1.next_cursor;
+
+  expect(namespaces0.namespaces.length).toEqual(5);
+  expect(namespaces0.namespaces.length).toEqual(5);
+  expect(cursor0).not.toEqual(cursor1);
+})
+
 test("schema", async () => {
   const ns = tpuf.namespace(testNamespacePrefix + "schema");
 

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -7,6 +7,47 @@ const tpuf = new Turbopuffer({
 
 const testNamespacePrefix = "typescript_sdk_";
 
+test("trailing_slashes_in_url", async () => {
+  const tpuf = new Turbopuffer({
+    apiKey: process.env.TURBOPUFFER_API_KEY!,
+    baseUrl: "https://gcp-us-east4.turbopuffer.com/",
+  });
+
+  const ns = tpuf.namespace(testNamespacePrefix + "trailing_slashes_in_url");
+
+  await ns.upsert({
+    vectors: [
+      {
+        id: 1,
+        vector: [0.1, 0.1],
+        attributes: {
+          text: "Walruses are large marine mammals with long tusks and whiskers",
+        },
+      },
+      {
+        id: 2,
+        vector: [0.2, 0.2],
+        attributes: { text: "They primarily inhabit the cold Arctic regions" },
+      },
+    ],
+    distance_metric: "cosine_distance",
+  });
+
+  const schema = await ns.schema();
+  expect(schema).toEqual({
+    id: {
+      type: 'uint',
+      filterable: null,
+      full_text_search: null,
+    },
+    text: {
+      type: 'string',
+      filterable: true,
+      full_text_search: null,
+    },
+  });
+});
+
 test("bm25_with_custom_schema_and_sum_query", async () => {
   const ns = tpuf.namespace(
     testNamespacePrefix + "bm25_with_custom_schema_and_sum_query",


### PR DESCRIPTION
If `baseUrl` already ends in a `/`, the end URL can become something like `https://gcp-europe-west3.turbopuffer.com//v1/namespaces/my_amazing_namespace/schema` and cause issues.

Additionally, when query params need to be added, the ? separator can be duplicated and cause issues. Eg. with a `.export({ cursor: 'my_next_cursor' })` call, the path would become `/v1/namespaces/export_testing??cursor=my_next_cursor` and thus not fetch the next page of results.

From https://developer.mozilla.org/en-US/docs/Web/API/URL/search:
> The search property of the [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) interface is a search string, also called a query string, that is a string containing a "?" followed by the parameters of the URL. If the URL does not have a search query, this property contains an empty string, "".