### PR TITLE
add ns.updateSchema()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbopuffer/turbopuffer",
-      "version": "0.6.11",
+      "version": "0.6.12",
       "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Official Typescript API client library for turbopuffer.com",
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -483,7 +483,7 @@ test("update_schema", async () => {
   });
 
   // Write an update to the schema making 'tags'
-  // filterable  and 'private' not filterable
+  // filterable and 'private' not filterable
   const updateSchema = await ns.updateSchema({
     tags: {
       type: "[]string",

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -360,6 +360,22 @@ export class Namespace {
   }
 
   /**
+   * Updates the schema for a namespace.
+   * Returns the final schema after updates are done.
+   * See https://turbopuffer.com/docs/schema for specifics on allowed updates.
+   */
+  async updateSchema(updatedSchema: Schema): Promise<Schema> {
+    return (
+      await this.client.http.doRequest<Schema>({
+        method: "POST",
+        path: `/v1/namespaces/${this.id}/schema`,
+        body: updatedSchema,
+        retryable: true,
+      })
+    ).body!;
+  }
+
+  /**
    * Copies all documents from another namespace to this namespace.
    * See: https://turbopuffer.com/docs/upsert#parameters `copy_from_namespace`
    * for specifics on how this works.


### PR DESCRIPTION
adds a `ns.updateSchema()` method (https://turbopuffer.com/docs/schema), similar to the Python SDK's `update_schema()`