### PR TITLE
Fix type of RankBy_Text

### DIFF
--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -158,7 +158,7 @@ test("bm25_with_tokenizer_pre_tokenized_array", async () => {
   });
 
   let results = await ns.query({
-    rank_by: ["content", "BM25", ["jumped"]],
+    rank_by: ["content", "BM25", ["jumped", "over"]],
     top_k: 10,
   });
   expect(results.length).toEqual(1);

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export type Schema = Record<
 
 export type RankBy_OrderByAttribute = [string, "asc" | "desc"];
 export type RankBy_Text =
-  | [string, "BM25", string | [string]]
+  | [string, "BM25", string | string[]]
   | ["Sum", RankBy_Text[]]
   | ["Product", [RankBy_Text, number]]
   | ["Product", [number, RankBy_Text]];


### PR DESCRIPTION
[string] is an array with exactly one string element, rather than an array with any number of string elements, as was intended.