### PR TITLE
Use v2 query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,19 @@ await ns.write({
 });
 
 const results = await ns.query({
-  vector: [1, 1],
+  rank_by: ["vector", "ANN", [1, 1]],
   filters: ["numbers", "In", [2, 4]],
 });
 
 // results:
-// [
-//   { id: 2, dist: 0.010050535 },
-//   { id: 1, dist: 0.051316738 },
-// ]
+// {
+//   rows: [
+//     { id: 2, dist: 0.010050535 },
+//     { id: 1, dist: 0.051316738 },
+//   ],
+//   billing: {...},
+//   performance: {...}
+// }
 ```
 
 To run the tests,

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ const results = await ns.query({
 // results:
 // {
 //   rows: [
-//     { id: 2, dist: 0.010050535 },
-//     { id: 1, dist: 0.051316738 },
+//     { id: 2, $dist: 0.010050535 },
+//     { id: 1, $dist: 0.051316738 },
 //   ],
 //   billing: {...},
 //   performance: {...}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbopuffer/turbopuffer",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Official Typescript API client library for turbopuffer.com",
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,7 +25,7 @@ function detectRuntime(): Runtime {
     userAgent
       ? userAgent === "Cloudflare-Workers"
       : // @ts-expect-error can be ignored
-        typeof WebSocketPair !== "undefined"
+      typeof WebSocketPair !== "undefined"
   )
     return "cloudflare-workers";
 
@@ -124,30 +124,6 @@ export function make_request_timing({
         ? deserialize_end - deserialize_start
         : null,
   };
-}
-
-export function parseIntMetric(value: string | null): number {
-  return value ? parseInt(value) : 0;
-}
-
-export function parseFloatMetric(value: string | null): number {
-  return value ? parseFloat(value) : 0;
-}
-
-export function parseServerTiming(value: string): Record<string, string> {
-  const output: Record<string, string> = {};
-  const sections = value.split(", ");
-  for (const section of sections) {
-    const tokens = section.split(";");
-    const base_key = tokens.shift();
-    for (const token of tokens) {
-      const components = token.split("=");
-      const key = base_key + "." + components[0];
-      const value = components[1];
-      output[key] = value;
-    }
-  }
-  return output;
 }
 
 export function shouldCompressWrite({

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -632,7 +632,7 @@ test("sanity", async () => {
   expect(resultsWithPerformance.rows[1].id).toEqual(1);
 
   const performance = resultsWithPerformance.performance;
-  // expect(performance.approx_namespace_size).toEqual(3); // TODO: fix this
+  expect(performance.approx_namespace_size).toEqual(3);
   expect(performance.exhaustive_search_count).toEqual(3);
   expect(performance.query_execution_ms).toBeGreaterThan(10);
   expect(performance.server_total_ms).toBeGreaterThan(10);
@@ -645,6 +645,12 @@ test("sanity", async () => {
   } else {
     expect(performance.decompress_time).toBeNull;
   }
+
+  const billing = resultsWithPerformance.billing;
+  expect(billing).toEqual({
+    billable_logical_bytes_queried: 256000000,
+    billable_logical_bytes_returned: 24,
+  });
 
   const results2 = await ns.query({
     rank_by: ["vector", "ANN", [1, 1]],

--- a/src/turbopuffer.ts
+++ b/src/turbopuffer.ts
@@ -129,7 +129,7 @@ export class Namespace {
     top_k?: number;
     include_attributes?: boolean | string[];
     filters?: Filters;
-    rank_by?: RankBy;
+    rank_by: RankBy;
     consistency?: Consistency;
   }): Promise<QueryResults> {
     const response = await this.client.http.doRequest<QueryResults>({

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,7 @@ export type QueryRow = RowDoc & RowAttributes & {
 export type QueryResults = {
   rows: QueryRow[];
   performance: QueryPerformance;
+  billing: QueryBilling;
 };
 
 export interface QueryPerformance extends RequestTiming {
@@ -183,6 +184,11 @@ export interface QueryPerformance extends RequestTiming {
   server_total_ms: number;
   query_execution_ms: number;
   exhaustive_search_count: number;
+}
+
+export interface QueryBilling {
+  billable_logical_bytes_queried: number;
+  billable_logical_bytes_returned: number;
 }
 
 export interface HintCacheWarmResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,13 +42,14 @@ export type Schema = Record<
   }
 >;
 
+export type RankBy_Vector = ["vector", "ANN", number[]];
 export type RankBy_OrderByAttribute = [string, "asc" | "desc"];
 export type RankBy_Text =
   | [string, "BM25", string | string[]]
   | ["Sum" | "Max", RankBy_Text[]]
   | ["Product", [RankBy_Text, number]]
   | ["Product", [number, RankBy_Text]];
-export type RankBy = RankBy_Text | RankBy_OrderByAttribute;
+export type RankBy = RankBy_Vector | RankBy_Text | RankBy_OrderByAttribute;
 
 export interface Consistency {
   level: "strong" | "eventual";
@@ -166,20 +167,21 @@ export interface WriteParams {
   encryption?: Encryption;
 }
 
-export type QueryResults = {
-  id: Id;
-  vector?: number[];
-  attributes?: RowAttributes;
-  dist?: number;
-  rank_by?: RankBy;
-}[];
+export type QueryRow = RowDoc & RowAttributes & {
+  $dist?: number;
+}
 
-export interface QueryMetrics extends RequestTiming {
+export type QueryResults = {
+  rows: QueryRow[];
+  performance: QueryPerformance;
+};
+
+export interface QueryPerformance extends RequestTiming {
   approx_namespace_size: number;
   cache_hit_ratio: number;
   cache_temperature: string;
-  processing_time: number;
-  query_execution_time: number;
+  server_total_ms: number;
+  query_execution_ms: number;
   exhaustive_search_count: number;
 }
 


### PR DESCRIPTION
One test expected to fail until https://github.com/turbopuffer/turbopuffer/pull/3697 goes in.

----

This is a SemVer-breaking change, as it introduces the following non-backwards compatible changes:

  * The `QueryResults` type changes from a list of rows directly to a type containing `rows: QueryRow[]`.

  * The `queryWithMetrics` method is removed in favor of returning performance metrics with every query via the new `QueryResults.performance` field.

  * `rank_by` is now a required parameter to `query`.

  * The `vector` parameter to query is removed and replaced by `rank_by: ["vector", "ANN", ...]`.

  * The `include_vectors` parameter to query is removed and replaced by `include_attributes: ["vector", ...]`.

  * Specifying `include_attributes: true` now includes the `vector` attribute.

  * The `distance_metric` parameter to query is removed with no replacement. (Specifying a distance metric on upserts is about to be required.)

Unlike the equivalent change to the Python SDK
(turbopuffer/turbopuffer-python#85), the new `QueryRow` type *does* flatten attributes. `id`, `vector`, and `$dist` are not given special handling.  This means the TypeScript `write` and `query` shapes are nicely aligned with the underlying JSON API shapes.