### PR TITLE
handle case when baseUrl doesnt have protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbopuffer/turbopuffer",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbopuffer/turbopuffer",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Official Typescript API client library for turbopuffer.com",
   "scripts": {
     "build": "rm -rf dist && tsc",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -55,6 +55,12 @@ export class TurbopufferError extends Error {
   }
 }
 
+export function buildBaseUrl(baseUrl: string) {
+  return baseUrl.trim().startsWith("https://")
+      ? baseUrl
+      : `https://${baseUrl}`;
+}
+
 export function buildUrl(
   baseUrl: string,
   path: string,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -56,9 +56,9 @@ export class TurbopufferError extends Error {
 }
 
 export function buildBaseUrl(baseUrl: string) {
-  return baseUrl.trim().startsWith("https://")
-      ? baseUrl
-      : `https://${baseUrl}`;
+  const url = baseUrl.trim();
+  const hasProtocol = url.includes("://");
+  return hasProtocol ? url : `https://${url}`;
 }
 
 export function buildUrl(

--- a/src/httpClient/default.ts
+++ b/src/httpClient/default.ts
@@ -6,6 +6,7 @@ import {
   statusCodeShouldRetry,
   delay,
   make_request_timing,
+  buildBaseUrl,
   buildUrl,
 } from "../helpers";
 
@@ -36,7 +37,7 @@ export default class DefaultHTTPClient implements HTTPClient {
     warmConnections: number,
     compression: boolean,
   ) {
-    this.baseUrl = baseUrl;
+    this.baseUrl = buildBaseUrl(baseUrl);
     this.origin = new URL(baseUrl);
     this.origin.pathname = "";
     this.apiKey = apiKey;

--- a/src/httpClient/node.ts
+++ b/src/httpClient/node.ts
@@ -15,6 +15,7 @@ import {
   statusCodeShouldRetry,
   delay,
   make_request_timing,
+  buildBaseUrl,
   buildUrl,
 } from "../helpers";
 
@@ -22,7 +23,7 @@ const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
 
 function convertHeadersType(
-  headers: Record<string, string | string[] | undefined>,
+  headers: Record<string, string | string[] | undefined>
 ): Record<string, string> {
   for (const key in headers) {
     const v = headers[key];
@@ -36,7 +37,7 @@ function convertHeadersType(
 }
 
 async function consumeResponseText(
-  response: Dispatcher.ResponseData,
+  response: Dispatcher.ResponseData
 ): Promise<TpufResponseWithMetadata> {
   if (response.headers["content-encoding"] === "gzip") {
     const body_buffer = await response.body.arrayBuffer();
@@ -67,10 +68,10 @@ export default class NodeHTTPClient implements HTTPClient {
     connectTimeout: number,
     idleTimeout: number,
     warmConnections: number,
-    compression: boolean,
+    compression: boolean
   ) {
-    this.baseUrl = baseUrl;
-    this.origin = new URL(baseUrl);
+    this.baseUrl = buildBaseUrl(baseUrl);
+    this.origin = new URL(this.baseUrl);
     this.origin.pathname = "";
     this.apiKey = apiKey;
     this.compression = compression;
@@ -185,7 +186,7 @@ export default class NodeHTTPClient implements HTTPClient {
           message ?? `http error ${response.statusCode}`,
           {
             status: response.statusCode,
-          },
+          }
         );
       }
       if (

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -1,5 +1,5 @@
 import { Turbopuffer, RankBy, Schema, TurbopufferError } from "./index";
-import { isRuntimeFullyNodeCompatible, buildUrl } from "./helpers";
+import { isRuntimeFullyNodeCompatible, buildBaseUrl, buildUrl } from "./helpers";
 
 const tpuf = new Turbopuffer({
   apiKey: process.env.TURBOPUFFER_API_KEY!,
@@ -1320,6 +1320,23 @@ test("readme", async () => {
 });
 
 // test helper and utility methods
+
+test("test_buildBaseUrl", () => {
+  expect(buildBaseUrl("gcp-us-east4.turbopuffer.com")).toEqual(
+    "https://gcp-us-east4.turbopuffer.com",
+  );
+  expect(buildBaseUrl("gcp-us-east4.turbopuffer.com")).not.toEqual(
+    "https://gcp-us-east4.turbopuffer.com/",
+  );
+
+  expect(buildBaseUrl("https://gcp-us-east4.turbopuffer.com")).toEqual(
+    "https://gcp-us-east4.turbopuffer.com",
+  );
+  expect(buildBaseUrl("https://gcp-us-east4.turbopuffer.com")).not.toEqual(
+    "https://gcp-us-east4.turbopuffer.com/",
+  );
+});
+
 test("test_buildUrl", () => {
   /** baseUrl w/o path **/
   /* w/o path + w/o query */

--- a/src/turbopuffer.test.ts
+++ b/src/turbopuffer.test.ts
@@ -1322,16 +1322,23 @@ test("readme", async () => {
 // test helper and utility methods
 
 test("test_buildBaseUrl", () => {
+  // if no protocol, add https://
   expect(buildBaseUrl("gcp-us-east4.turbopuffer.com")).toEqual(
     "https://gcp-us-east4.turbopuffer.com",
   );
-  expect(buildBaseUrl("gcp-us-east4.turbopuffer.com")).not.toEqual(
-    "https://gcp-us-east4.turbopuffer.com/",
-  );
 
+  // if any protocol (or protocol-looking string) exists, do nothing
   expect(buildBaseUrl("https://gcp-us-east4.turbopuffer.com")).toEqual(
     "https://gcp-us-east4.turbopuffer.com",
   );
+  expect(buildBaseUrl("http://gcp-us-east4.turbopuffer.com")).toEqual(
+    "http://gcp-us-east4.turbopuffer.com",
+  );
+  expect(buildBaseUrl("admin://gcp-us-east4.turbopuffer.com")).toEqual(
+    "admin://gcp-us-east4.turbopuffer.com",
+  );
+
+  // do not add trailing /
   expect(buildBaseUrl("https://gcp-us-east4.turbopuffer.com")).not.toEqual(
     "https://gcp-us-east4.turbopuffer.com/",
   );


### PR DESCRIPTION
for better DX, allow users to use a baseUrl without the protocol (this is what browsers implicitly do too for eg.). One scenario where this can happen is if you copy a region from the site regions page