### PR TITLE
fix: strict types for async query and multi_query APIs

### DIFF
--- a/src/resources/namespaces.ts
+++ b/src/resources/namespaces.ts
@@ -538,7 +538,7 @@ export namespace NamespaceMultiQueryParams {
      * Aggregations to compute over all documents in the namespace that match the
      * filters.
      */
-    aggregate_by?: Record<string, unknown>;
+    aggregate_by?: Record<string, AggregateBy>;
 
     /**
      * A function used to calculate vector similarity.
@@ -549,7 +549,7 @@ export namespace NamespaceMultiQueryParams {
      * Exact filters for attributes to refine search results for. Think of it as a SQL
      * WHERE clause.
      */
-    filters?: unknown;
+    filters?: Filter;
 
     /**
      * Whether to include attributes in the response.
@@ -559,7 +559,7 @@ export namespace NamespaceMultiQueryParams {
     /**
      * How to rank the documents in the namespace.
      */
-    rank_by?: unknown;
+    rank_by?: RankBy;
 
     /**
      * The number of results to return.

--- a/tests/api-resources/namespaces.test.ts
+++ b/tests/api-resources/namespaces.test.ts
@@ -63,11 +63,9 @@ describe('resource namespaces', () => {
       namespace: 'namespace',
       queries: [
         {
-          aggregate_by: { foo: 'bar' },
           distance_metric: 'cosine_distance',
-          filters: {},
           include_attributes: true,
-          rank_by: {},
+          rank_by: ['id', 'asc'],
           top_k: 0,
         },
       ],


### PR DESCRIPTION
This type was missing the necessary custom code to stitch in our stricter types for the `aggregate_by`, `filters`, and `rank_by` parameters.