### PR TITLE
fix: dynamic import file paths

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -38,6 +38,9 @@ node scripts/utils/make-dist-package-json.cjs > dist/package.json
 node scripts/utils/fix-index-exports.cjs
 cp tsconfig.dist-src.json dist/src/tsconfig.json
 
+# fix dynamic imports
+node scripts/utils/fix-dynamic-imports.cjs
+
 node scripts/utils/postprocess-files.cjs
 
 # make sure that nothing crashes when we require the output CJS or

--- a/scripts/utils/fix-dynamic-imports.cjs
+++ b/scripts/utils/fix-dynamic-imports.cjs
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+// `importDynamic` is defined in `src/internal/shims.ts`
+const IMPORT_DYNAMIC_PATTERN = /importDynamic\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
+
+function processFiles(pattern, transformPath) {
+  const files = glob.sync(pattern);
+
+  files.forEach((file) => {
+    let content = fs.readFileSync(file, 'utf8');
+    let modified = false;
+
+    content = content.replace(IMPORT_DYNAMIC_PATTERN, (match, importPath) => {
+      // only process relative imports
+      if (importPath.startsWith('.')) {
+        const newPath = transformPath(importPath, file);
+        if (newPath !== importPath) {
+          modified = true;
+          return `importDynamic('${newPath}')`;
+        }
+      }
+      return match;
+    });
+
+    if (modified) fs.writeFileSync(file, content);
+  });
+}
+
+function resolveImportPath(importPath, fromFile, extension, indexFile) {
+  // already has an extension
+  if (path.extname(importPath)) {
+    return importPath;
+  }
+
+  // resolve the path relative to the file containing the import
+  const fromDir = path.dirname(fromFile);
+  const resolvedPath = path.resolve(fromDir, importPath);
+
+  // check if it's a file with the specified extension
+  if (fs.existsSync(resolvedPath + extension)) {
+    return importPath + extension;
+  }
+
+  // check if it's a directory with the specified index file
+  if (fs.existsSync(path.join(resolvedPath, indexFile))) {
+    return importPath + '/' + indexFile;
+  }
+
+  return importPath + extension;
+}
+
+function transformESMPath(importPath, fromFile) {
+  return resolveImportPath(importPath, fromFile, '.mjs', 'index.mjs');
+}
+
+function transformCJSPath(importPath, fromFile) {
+  const result = resolveImportPath(importPath, fromFile, '.js', 'index.js');
+  // leave as-is for commonjs (node can resolve without extension)
+  return result.endsWith('.js') ? result : importPath;
+}
+
+processFiles('dist/**/*.mjs', transformESMPath);
+
+processFiles('dist/**/*.js', transformCJSPath);

--- a/src/lib/compressor.ts
+++ b/src/lib/compressor.ts
@@ -13,6 +13,7 @@ export const makeGzipCompressor = async () => {
   if (isRuntimeFullyNodeCompatible) {
     // Use `importDynamic` to hide this import from Vite, as it's not available
     // in edge environments like Cloudflare Workers.
+    // This has to be `../lib` because it'll be called from `src/internal/shims.ts`.
     gzip = (await importDynamic('../lib/gzip-node')).default;
   } else {
     // `gzip-pako` is compatible with edge environments so we can use


### PR DESCRIPTION
the dynamic import solution we added in https://github.com/turbopuffer/turbopuffer-typescript/pull/112 prevents tsc/tsc-multi from discovering the import and resolving to the correct file path and file extension when you build (`npm run build`).

This is what `node_modules/@turbopuffer/turbopuffer/dist/lib/compressor.mjs` looks like (same issue with `fetch-undici` in `shims.mjs`):
```js
import { importDynamic } from "../internal/shims.mjs";
import { isRuntimeFullyNodeCompatible } from "./runtime.mjs";
// Chosen based on limited testing. May need tuning.
const MIN_GZIP_SIZE = 1024;
export const makeGzipCompressor = async () => {
    let gzip;
    if (isRuntimeFullyNodeCompatible) {
        // Use `importDynamic` to hide this import from Vite, as it's not available
        // in edge environments like Cloudflare Workers.
        gzip = (await importDynamic('../lib/gzip-node')).default;    // <------- NOTE no file extension
    }
    else {
        // `gzip-pako` is compatible with edge environments so we can use
        // a normal import.
        gzip = (await import("./gzip-pako.mjs")).default;    // <------- NOTE file extension
    }
    ...
```

after this PR's changes:
```js
import { importDynamic } from "../internal/shims.mjs";
import { isRuntimeFullyNodeCompatible } from "./runtime.mjs";
// Chosen based on limited testing. May need tuning.
const MIN_GZIP_SIZE = 1024;
export const makeGzipCompressor = async () => {
    let gzip;
    if (isRuntimeFullyNodeCompatible) {
        // Use `importDynamic` to hide this import from Vite, as it's not available
        // in edge environments like Cloudflare Workers.
        // This has to be `../lib` because it'll be called from `src/internal/shims.ts`.
        gzip = (await importDynamic('../lib/gzip-node.mjs')).default;    // <------- NOTE file extension
    }
    else {
        // `gzip-pako` is compatible with edge environments so we can use
        // a normal import.
        gzip = (await import("./gzip-pako.mjs")).default;    // <------- NOTE still has file extension
    }