### PR TITLE
build: improve smoke test

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -40,6 +40,10 @@ cp tsconfig.dist-src.json dist/src/tsconfig.json
 
 node scripts/utils/postprocess-files.cjs
 
+# instruct Vite and other bundlers to ignore the imports that are only
+# available in Node.js
+node scripts/utils/fix-bundle-ignore-imports.cjs
+
 # make sure that nothing crashes when we require the output CJS or
 # import the output ESM
 (cd dist && node ../scripts/utils/smoke-test.cjs)

--- a/scripts/build
+++ b/scripts/build
@@ -42,8 +42,8 @@ node scripts/utils/postprocess-files.cjs
 
 # make sure that nothing crashes when we require the output CJS or
 # import the output ESM
-(cd dist && node -e 'require("@turbopuffer/turbopuffer")')
-(cd dist && node -e 'import("@turbopuffer/turbopuffer")' --input-type=module)
+(cd dist && node ../scripts/utils/smoke-test.cjs)
+(cd dist && node ../scripts/utils/smoke-test.mjs)
 
 if [ -e ./scripts/build-deno ]
 then

--- a/scripts/utils/fix-bundle-ignore-imports.cjs
+++ b/scripts/utils/fix-bundle-ignore-imports.cjs
@@ -24,14 +24,3 @@ glob.sync('dist/**/*.mjs').forEach((file) => {
     fs.writeFileSync(file, transformed);
   }
 });
-
-glob.sync('dist/**/*.js').forEach((file) => {
-  const code = fs.readFileSync(file, 'utf8');
-  const transformed = code.replace(
-    /require\("([^"]+)"\)(.*) \/\/ @tpuf-bundler-ignore\n/gm,
-    'require((() => "$1")())$2\n',
-  );
-  if (transformed !== code) {
-    fs.writeFileSync(file, transformed);
-  }
-});

--- a/scripts/utils/fix-bundle-ignore-imports.cjs
+++ b/scripts/utils/fix-bundle-ignore-imports.cjs
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const glob = require('glob');
+
+// Find code like:
+//
+//     import("path/to/file"); // @tpuf-bundler-ignore
+//
+// and replace it with code like:
+//
+//   import((() => "path/to/file")());
+//
+// which hides it from Vite, Webpack, and other bundlers. Used with
+// Node.js-specific modules that can't be bundled for other environments like
+// Cloudflare Workers. (Bundlers aren't smart enough to understand the
+// isRuntimeFullyNodeCompatible check on their own.)
+
+glob.sync('dist/**/*.mjs').forEach((file) => {
+  const code = fs.readFileSync(file, 'utf8');
+  const transformed = code.replace(
+    /import\("([^"]+)"\)(.*) \/\/ @tpuf-bundler-ignore\n/gm,
+    'import((() => "$1")())$2\n',
+  );
+  if (transformed !== code) {
+    fs.writeFileSync(file, transformed);
+  }
+});

--- a/scripts/utils/fix-bundle-ignore-imports.cjs
+++ b/scripts/utils/fix-bundle-ignore-imports.cjs
@@ -24,3 +24,14 @@ glob.sync('dist/**/*.mjs').forEach((file) => {
     fs.writeFileSync(file, transformed);
   }
 });
+
+glob.sync('dist/**/*.js').forEach((file) => {
+  const code = fs.readFileSync(file, 'utf8');
+  const transformed = code.replace(
+    /require\("([^"]+)"\)(.*) \/\/ @tpuf-bundler-ignore\n/gm,
+    'require((() => "$1")())$2\n',
+  );
+  if (transformed !== code) {
+    fs.writeFileSync(file, transformed);
+  }
+});

--- a/scripts/utils/smoke-test.cjs
+++ b/scripts/utils/smoke-test.cjs
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const turbopuffer = require('@turbopuffer/turbopuffer');
+
+async function main() {
+  const tpuf = new turbopuffer.Turbopuffer({
+    apiKey: 'ignored-for-root-endpoint',
+    region: 'gcp-us-central1',
+  });
+
+  // Do an actual request to the API to test the dynamic imports of
+  // undici and gzip.
+  const res = await tpuf.get('/');
+  assert(res.status === '🐡');
+
+  console.log('CJS smoke test passed');
+}
+
+main();

--- a/scripts/utils/smoke-test.mjs
+++ b/scripts/utils/smoke-test.mjs
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import turbopuffer from '@turbopuffer/turbopuffer'; // eslint-disable-line no-restricted-imports
+
+async function main() {
+  const tpuf = new turbopuffer.Turbopuffer({
+    apiKey: 'ignored-for-root-endpoint',
+    region: 'gcp-us-central1',
+  });
+
+  // Do an actual request to the API to test the dynamic imports of
+  // undici and gzip.
+  const res = await tpuf.get('/');
+  assert(res.status === '🐡');
+
+  console.log('ESM smoke test passed');
+}
+
+main();

--- a/src/internal/shims.ts
+++ b/src/internal/shims.ts
@@ -12,25 +12,9 @@ import { isRuntimeFullyNodeCompatible } from '../lib/runtime';
 import type { Fetch } from './builtin-types';
 import type { ReadableStream } from './shim-types';
 
-/**
- * Like the built-in `import` function, but prevents the static analysis that certain bundlers
- * can perform when static paths are passed directly to `import`.
- *
- * Specifically, this prevents Vite's [dep-optimizer](https://vite.dev/guide/dep-pre-bundling.html)
- * from pre-bundling the import and causing errors — without this, `vite dev` will unconditionally
- * try to import the dependency, even when targeting edge environments like Cloudflare Workers
- * where the dependency is not compatible.
- */
-export async function importDynamic(path: string) {
-  return await import(path);
-}
-
 export async function getDefaultFetch(options: HttpClientOptions): Promise<Fetch> {
   if (isRuntimeFullyNodeCompatible) {
-    // Use `importDynamic` to hide this import from Vite. `undici` depends on
-    // `node:sqlite`, which is not available in edge environments like
-    // Cloudflare Workers.
-    const { makeFetchUndici } = await importDynamic('../lib/fetch-undici');
+    const { makeFetchUndici } = await import('../lib/fetch-undici'); // @tpuf-bundler-ignore
     return makeFetchUndici(options);
   } else if (typeof fetch !== 'undefined') {
     const fetchSmuggling: typeof fetch = async (url, options) => {

--- a/src/lib/compressor.ts
+++ b/src/lib/compressor.ts
@@ -1,5 +1,4 @@
 import { EncodedContent } from '../internal/request-options';
-import { importDynamic } from '../internal/shims';
 import { isRuntimeFullyNodeCompatible } from './runtime';
 
 export type Compressor = (content: EncodedContent) => Promise<EncodedContent>;
@@ -11,12 +10,10 @@ export const makeGzipCompressor = async () => {
   let gzip: (data: string) => Promise<Uint8Array>;
 
   if (isRuntimeFullyNodeCompatible) {
-    // Use `importDynamic` to hide this import from Vite, as it's not available
-    // in edge environments like Cloudflare Workers.
-    gzip = (await importDynamic('../lib/gzip-node')).default;
+    gzip = (await import('./gzip-node')).default; // @tpuf-bundler-ignore
   } else {
-    // `gzip-pako` is compatible with edge environments so we can use
-    // a normal import.
+    // `gzip-pako` is compatible with edge environments so no need to hide
+    // this import from bundlers.
     gzip = (await import('./gzip-pako')).default;
   }
 


### PR DESCRIPTION
Beef up the smoke test in scripts/build that checks the validity of the compiles JavaScript so that it can detect the issue @Arash-11 is fixing in #117.