### PR TITLE
fix: dynamic import file path

### DIFF
--- a/scripts/utils/fix-bundle-ignore-imports.cjs
+++ b/scripts/utils/fix-bundle-ignore-imports.cjs
@@ -1,26 +1,51 @@
 const fs = require('fs');
 const glob = require('glob');
+const path = require('path');
 
 // Find code like:
 //
-//     import("path/to/file"); // @tpuf-bundler-ignore
+//    import("path/to/file"); // @tpuf-bundler-ignore
 //
 // and replace it with code like:
 //
-//   import((() => "path/to/file")());
+//    import((() => "@turbopuffer/turbopuffer/path/to/file")());
 //
-// which hides it from Vite, Webpack, and other bundlers. Used with
+// which hides it from Vite, Webpack, and other bundlers while using absolute
+// package paths that work regardless of current working directory. Used with
 // Node.js-specific modules that can't be bundled for other environments like
 // Cloudflare Workers. (Bundlers aren't smart enough to understand the
 // isRuntimeFullyNodeCompatible check on their own.)
 
+const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'));
+const packageName = packageJson.name;
+
+function resolvePathRelativeToPackage(relativePath, currentFilePath) {
+  const distRelativePath = path.relative('dist', currentFilePath);
+  const dirOfCurrentFile = path.dirname(distRelativePath);
+
+  const resolvedPath = path.resolve('/', dirOfCurrentFile, relativePath);
+
+  // convert to package-relative path (remove leading slash and normalize)
+  const packageRelativePath = resolvedPath.substring(1).replace(/\\/g, '/');
+
+  return `${packageName}/${packageRelativePath}`;
+}
+
+function transformBundlerIgnoreImports(code, filePath, packageName) {
+  return code.replace(/import\("([^"]+)"\)(.*) \/\/ @tpuf-bundler-ignore\n/gm, (_, importPath, rest) => {
+    // transform relative paths (starting with . or ..)
+    if (importPath.startsWith('.')) {
+      const absolutePackagePath = resolvePathRelativeToPackage(importPath, filePath, packageName);
+      return `import((() => "${absolutePackagePath}")())${rest}\n`;
+    }
+    return `import((() => "${importPath}")())${rest}\n`;
+  });
+}
+
 glob.sync('dist/**/*.mjs').forEach((file) => {
   const code = fs.readFileSync(file, 'utf8');
-  const transformed = code.replace(
-    /import\("([^"]+)"\)(.*) \/\/ @tpuf-bundler-ignore\n/gm,
-    'import((() => "$1")())$2\n',
-  );
-  if (transformed !== code) {
-    fs.writeFileSync(file, transformed);
-  }
+  const transformed = transformBundlerIgnoreImports(code, file, packageName);
+  if (transformed !== code) fs.writeFileSync(file, transformed);
 });
+
+module.exports = { resolvePathRelativeToPackage, transformBundlerIgnoreImports };

--- a/tests/bundler-ignore-paths.test.ts
+++ b/tests/bundler-ignore-paths.test.ts
@@ -1,0 +1,101 @@
+const {
+  resolvePathRelativeToPackage,
+  transformBundlerIgnoreImports,
+} = require('../scripts/utils/fix-bundle-ignore-imports.cjs');
+
+describe('bundler ignore path resolution', () => {
+  const packageName = '@turbopuffer/turbopuffer';
+
+  test('resolves relative paths from internal/shims.mjs to lib/fetch-undici', () => {
+    const result = resolvePathRelativeToPackage(
+      '../lib/fetch-undici',
+      'dist/internal/shims.mjs',
+      packageName,
+    );
+    expect(result).toBe('@turbopuffer/turbopuffer/lib/fetch-undici');
+  });
+
+  test('resolves relative paths from lib/compressor.mjs to lib/gzip-node', () => {
+    const result = resolvePathRelativeToPackage('./gzip-node', 'dist/lib/compressor.mjs', packageName);
+    expect(result).toBe('@turbopuffer/turbopuffer/lib/gzip-node');
+  });
+
+  test('handles deeply nested relative paths', () => {
+    const result = resolvePathRelativeToPackage(
+      '../../lib/some-module',
+      'dist/internal/utils/helper.mjs',
+      packageName,
+    );
+    expect(result).toBe('@turbopuffer/turbopuffer/lib/some-module');
+  });
+
+  test('handles same-directory relative paths', () => {
+    const result = resolvePathRelativeToPackage('./sibling-module', 'dist/lib/main.mjs', packageName);
+    expect(result).toBe('@turbopuffer/turbopuffer/lib/sibling-module');
+  });
+
+  test('handles relative paths that go to root', () => {
+    const result = resolvePathRelativeToPackage('../index', 'dist/lib/compressor.mjs', packageName);
+    expect(result).toBe('@turbopuffer/turbopuffer/index');
+  });
+});
+
+describe('bundler ignore transformation integration', () => {
+  const packageName = '@turbopuffer/turbopuffer';
+
+  test('transforms relative import with @tpuf-bundler-ignore comment', () => {
+    const sourceCode = `export async function getDefaultFetch(options: HttpClientOptions): Promise<Fetch> {
+  if (isRuntimeFullyNodeCompatible) {
+    const { makeFetchUndici } = await import("../lib/fetch-undici"); // @tpuf-bundler-ignore
+    return makeFetchUndici(options);
+  }
+  return fetch;
+}`;
+
+    const expectedCode = `export async function getDefaultFetch(options: HttpClientOptions): Promise<Fetch> {
+  if (isRuntimeFullyNodeCompatible) {
+    const { makeFetchUndici } = await import((() => "@turbopuffer/turbopuffer/lib/fetch-undici")());
+    return makeFetchUndici(options);
+  }
+  return fetch;
+}`;
+
+    const result = transformBundlerIgnoreImports(sourceCode, 'dist/internal/shims.mjs', packageName);
+    expect(result).toBe(expectedCode);
+  });
+
+  test('transforms same-directory relative import', () => {
+    const sourceCode = `export const makeGzipCompressor = async () => {
+  let gzip;
+  if (isRuntimeFullyNodeCompatible) {
+    gzip = (await import("./gzip-node")).default; // @tpuf-bundler-ignore
+  }
+  return gzip;
+};`;
+
+    const expectedCode = `export const makeGzipCompressor = async () => {
+  let gzip;
+  if (isRuntimeFullyNodeCompatible) {
+    gzip = (await import((() => "@turbopuffer/turbopuffer/lib/gzip-node")())).default;
+  }
+  return gzip;
+};`;
+
+    const result = transformBundlerIgnoreImports(sourceCode, 'dist/lib/compressor.mjs', packageName);
+    expect(result).toBe(expectedCode);
+  });
+
+  test('leaves non-relative imports unchanged but still hides from bundler', () => {
+    const sourceCode = `const module = await import("some-package"); // @tpuf-bundler-ignore\n`;
+    const expectedCode = `const module = await import((() => "some-package")());\n`;
+
+    const result = transformBundlerIgnoreImports(sourceCode, 'dist/any/file.mjs', packageName);
+    expect(result).toBe(expectedCode);
+  });
+
+  test('leaves imports without @tpuf-bundler-ignore comment unchanged', () => {
+    const sourceCode = `const module = await import("../lib/some-module");`;
+    const result = transformBundlerIgnoreImports(sourceCode, 'dist/internal/shims.mjs', packageName);
+    expect(result).toBe(sourceCode);
+  });
+});


### PR DESCRIPTION
There are some issues with the dynamic import in some environments (eg. SST). The issue is that relative import paths like `./gzip-node` isn't resolving correctly.

Transforming these relative import paths to absolute package paths (e.g. `./gzip-node` -> `@turbopuffer/turbopuffer/lib/gzip-node`) ensures imports work regardless of the current working directory or how the bundler processes the files, while still hiding these imports from static analysis.