### PR TITLE
fix(mcp-server): handle GET requests for Azure Foundry compatibility

### DIFF
--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -54,15 +54,15 @@ const post =
     await transport.handleRequest(req, res, req.body);
   };
 
-const get = async (req: express.Request, res: express.Response) => {
-  res.status(405).json({
-    jsonrpc: '2.0',
-    error: {
-      code: -32000,
-      message: 'Method not supported',
-    },
-  });
-};
+const get =
+  (options: { clientOptions: ClientOptions; mcpOptions: McpOptions }) =>
+  async (req: express.Request, res: express.Response) => {
+    const server = newServer({ ...options, req, res });
+    if (server === null) return;
+    const transport = new StreamableHTTPServerTransport();
+    await server.connect(transport as any);
+    await transport.handleRequest(req, res);
+  };
 
 const del = async (req: express.Request, res: express.Response) => {
   res.status(405).json({
@@ -98,7 +98,7 @@ export const streamableHTTPApp = ({
     app.use(morgan('combined'));
   }
 
-  app.get('/', get);
+  app.get('/', get({ clientOptions, mcpOptions }));
   app.post('/', post({ clientOptions, mcpOptions }));
   app.delete('/', del);
 


### PR DESCRIPTION
## Summary
- Routes GET requests through `StreamableHTTPServerTransport` instead of returning 405 "Method not supported"
- GET handler now mirrors POST — creates a server, connects a transport, and delegates to the SDK
- Needed for Azure Foundry, which sends GET to enumerate tools before making any POST calls

## Context
Azure Foundry's Agent Service sends a GET request to the MCP endpoint to discover available tools. The current handler rejects this with 405, blocking tool enumeration entirely. The MCP SDK's `StreamableHTTPServerTransport` already has built-in GET handling for SSE streams — we just need to route requests through it.

## Separate issue
The `stlmcp.com` deployment also needs `TURBOPUFFER_REGION` set as an environment variable (e.g., `gcp-us-central1`). Without it, the Turbopuffer SDK client fails to construct a base URL. This is a deployment config change, not a code change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the MCP HTTP endpoint behavior for `GET /` from an explicit 405 to SDK-driven handling, which could affect client compatibility and request/connection behavior (e.g., SSE) but is limited in scope to one route.
> 
> **Overview**
> Adds first-class `GET /` support on the streamable HTTP MCP endpoint by creating an MCP server instance, connecting `StreamableHTTPServerTransport`, and delegating request handling to the SDK (mirroring the existing POST flow).
> 
> Updates the Express route wiring so `GET /` uses the new handler instead of returning a 405 "Method not supported" response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 851d6b8e6e2b6d3d3c1ee5e712f75fbfd802a10b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->