### PR TITLE
mcp: default region to gcp-us-central1

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -67,6 +67,7 @@ export async function initMcpServer(params: {
       try {
         _client = new Turbopuffer({
           ...{ defaultNamespace: readEnv('TURBOPUFFER_DEFAULT_NAMESPACE') },
+          region: readEnv('TURBOPUFFER_REGION') ?? 'gcp-us-central1',
           logger,
           ...params.clientOptions,
           defaultHeaders: {


### PR DESCRIPTION
## Summary
- Defaults region to `gcp-us-central1` in the MCP server only (not SDK-wide)
- Azure Foundry only allows passing an API key to MCP servers — no custom headers or env vars — so the Stainless-hosted server at `turbopuffer.stlmcp.com` can't receive `TURBOPUFFER_REGION`
- SDK clients still require an explicit region (no behavior change for Python/TS/Go/etc.)
- Local MCP users can still override via `TURBOPUFFER_REGION` env var or `clientOptions.region`

Companion to turbopuffer/turbopuffer#7829 (which reverts the SDK-wide default per @benesch's feedback)

## Test plan
- [ ] Verify hosted MCP server at `turbopuffer.stlmcp.com` works without `TURBOPUFFER_REGION` set
- [ ] Verify SDK clients still error when region is not provided
- [ ] Verify `TURBOPUFFER_REGION` env var still overrides the default


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes MCP server client initialization by adding a fallback region, with existing env/config overrides still taking precedence.
> 
> **Overview**
> The MCP server now defaults the Turbopuffer client `region` to `gcp-us-central1` when `TURBOPUFFER_REGION` is not set, improving compatibility with environments that can’t pass region configuration.
> 
> Explicit region configuration via `TURBOPUFFER_REGION` and existing `clientOptions` remains supported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52d9aff669886bd75629fcf367f2443cd8901d6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->