### PR TITLE
docs: Update supported Node.js to 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ TypeScript >= 4.9 is supported.
 The following runtimes are supported:
 
 - Web browsers (Up-to-date Chrome, Firefox, Safari, Edge, and more)
-- Node.js 20 LTS or later ([non-EOL](https://endoflife.date/nodejs)) versions.
+- Node.js 22 LTS or later ([non-EOL](https://endoflife.date/nodejs)) versions.
 - Deno v1.28.0 or higher.
 - Bun 1.0 or later.
 - Cloudflare Workers.


### PR DESCRIPTION
Node 20 is EOL (https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch)