### PR TITLE
feat: transparent async polling

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -94,6 +94,7 @@ import {
 import { isEmptyObj } from './internal/utils/values';
 import { compress } from './internal/custom/compress';
 import { RequestClock } from './internal/custom/performance';
+import * as RespondAsync from './internal/custom/respond-async';
 import { makeFetch } from '#fetch';
 
 export interface ClientOptions {
@@ -423,7 +424,9 @@ export class Turbopuffer {
   /**
    * Used as a callback for mutating the given `FinalRequestOptions` object.
    */
-  protected async prepareOptions(options: FinalRequestOptions): Promise<void> {}
+  protected async prepareOptions(options: FinalRequestOptions): Promise<void> {
+    RespondAsync.prepareOptions(options);
+  }
 
   /**
    * Used as a callback for mutating the given `RequestInit` object.
@@ -520,7 +523,7 @@ export class Turbopuffer {
     }
 
     const controller = new AbortController();
-    const response = await this.fetchWithTimeout(url, req, timeout, controller).catch(castToError);
+    let response = await this.fetchWithTimeout(url, req, timeout, controller).catch(castToError);
     const headersTime = Date.now();
 
     if (response instanceof globalThis.Error) {
@@ -633,6 +636,8 @@ export class Turbopuffer {
         durationMs: headersTime - startTime,
       }),
     );
+
+    response = await RespondAsync.maybePoll(this, response, options, clock);
 
     clock.deserializeStart = performance.now();
 

--- a/src/internal/custom/respond-async.ts
+++ b/src/internal/custom/respond-async.ts
@@ -1,0 +1,131 @@
+/**
+ * Transparent polling for tpuf APIs that accept `prefer: respond-async`.
+ *
+ * Every API request is stamped with `prefer: respond-async`. If the server
+ * applies the preference (i.e. responds with `202 Accepted` +
+ * `preference-applied: respond-async`) the SDK polls the operation URL
+ * until it finishes and returns the final result as if the call had been
+ * synchronous.
+ */
+
+import { type Turbopuffer } from '../../client';
+import * as Errors from '../../core/error';
+import { buildHeaders } from '../headers';
+import { type RequestClock } from './performance';
+import { type FinalRequestOptions } from '../request-options';
+import { sleep } from '../utils/sleep';
+
+const HEADER_PREFER = 'prefer';
+const HEADER_PREFERENCE_APPLIED = 'preference-applied';
+const HEADER_LOCATION = 'location';
+const RESPOND_ASYNC = 'respond-async';
+
+/** tunables; mutable so tests can override */
+export const config = {
+  pollIntervalMs: 1000,
+  pollRequestTimeoutMs: 60_000,
+};
+
+export function prepareOptions(options: FinalRequestOptions): void {
+  const normalized = buildHeaders([options.headers]);
+
+  // Don't overwrite an existing `prefer` header. This allows the caller to disable async mode.
+  if (normalized.values.has(HEADER_PREFER) || normalized.nulls.has(HEADER_PREFER)) {
+    return;
+  }
+
+  normalized.values.set(HEADER_PREFER, RESPOND_ASYNC);
+  options.headers = normalized;
+}
+
+export async function maybePoll(
+  client: Turbopuffer,
+  response: Response,
+  options: FinalRequestOptions,
+  clock: RequestClock,
+): Promise<Response> {
+  if (!respondAsyncApplied(response)) return response;
+
+  const location = response.headers.get(HEADER_LOCATION);
+  if (!location) {
+    throw new Errors.TurbopufferError('server returned async response without a `location` header');
+  }
+
+  const timeout = new Timeout(options.timeout ?? client.timeout);
+
+  while (true) {
+    if (timeout.remainingMs() === 0) {
+      throw new Errors.APIConnectionTimeoutError();
+    }
+
+    const poll = await client.get<PollBody>(location, {
+      headers: { [HEADER_PREFER]: null },
+      timeout: timeout.pollTimeoutMs(),
+    });
+
+    const resp = resolvePollResponse(poll, clock);
+    if (resp) return resp;
+
+    await sleep(timeout.sleepDurationMs());
+  }
+}
+
+function resolvePollResponse(body: PollBody, clock: RequestClock): Response | null {
+  if (body.status === 'running') return null;
+
+  if (body.result?.success) {
+    const resp = new Response(JSON.stringify(body.result.success), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+    // Carry the original request's clock so client perf metrics propagate correctly.
+    Object.defineProperty(resp, 'clock', { value: clock, enumerable: true });
+    return resp;
+  }
+
+  if (body.result?.error) {
+    const err = body.result.error;
+    throw Errors.APIError.generate(err.status_code, err.detail as object, undefined, new Headers());
+  }
+
+  throw new Errors.TurbopufferError('malformed poll response');
+}
+
+function respondAsyncApplied(response: Response): boolean {
+  if (response.status !== 202) return false;
+  const applied = response.headers.get(HEADER_PREFERENCE_APPLIED) ?? '';
+  return applied.trim().toLowerCase() === RESPOND_ASYNC;
+}
+
+type PollBody = {
+  status: 'running' | 'finished';
+  result?: {
+    success?: unknown;
+    error?: {
+      status_code: number;
+      detail?: unknown;
+    };
+  };
+};
+
+const nowMs = () => Math.floor(performance.now());
+
+class Timeout {
+  private readonly deadline: number;
+
+  constructor(timeoutMs: number | undefined) {
+    this.deadline = timeoutMs === undefined ? Infinity : nowMs() + timeoutMs;
+  }
+
+  remainingMs(): number {
+    return Math.max(this.deadline - nowMs(), 0);
+  }
+
+  pollTimeoutMs(): number {
+    return Math.min(this.remainingMs(), config.pollRequestTimeoutMs);
+  }
+
+  sleepDurationMs(): number {
+    return Math.min(this.remainingMs(), config.pollIntervalMs);
+  }
+}

--- a/src/internal/custom/respond-async.ts
+++ b/src/internal/custom/respond-async.ts
@@ -61,6 +61,7 @@ export async function maybePoll(
     const poll = await client.get<PollBody>(location, {
       headers: { [HEADER_PREFER]: null },
       timeout: timeout.pollTimeoutMs(),
+      signal: options.signal,
     });
 
     const resp = resolvePollResponse(poll, clock);

--- a/src/internal/custom/respond-async.ts
+++ b/src/internal/custom/respond-async.ts
@@ -73,7 +73,7 @@ export async function maybePoll(
 function resolvePollResponse(body: PollBody, clock: RequestClock): Response | null {
   if (body.status === 'running') return null;
 
-  if (body.result?.success) {
+  if (body.result && 'success' in body.result) {
     const resp = new Response(JSON.stringify(body.result.success), {
       status: 200,
       headers: { 'content-type': 'application/json' },

--- a/tests/respondAsync.test.ts
+++ b/tests/respondAsync.test.ts
@@ -1,5 +1,6 @@
 import Turbopuffer, {
   APIConnectionTimeoutError,
+  APIUserAbortError,
   InternalServerError,
   NotFoundError,
 } from '@turbopuffer/turbopuffer';
@@ -186,4 +187,25 @@ test('persistent poll error throws', async () => {
     client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } }),
   ).rejects.toThrow(InternalServerError);
   expect(polls).toEqual(1);
+});
+
+test('abort during polling throws', async () => {
+  const controller = new AbortController();
+  let polls = 0;
+  const testFetch = async (url: string | URL | Request): Promise<Response> => {
+    if (String(url) === POLL_URL) {
+      polls++;
+      if (polls === 2) controller.abort();
+      return jsonResponse(200, { status: 'running' });
+    }
+    return asyncAppliedResponse(POLL_URL);
+  };
+
+  const client = new Turbopuffer({ baseURL: BASE_URL, apiKey: 'tpuf_A1...', fetch: testFetch });
+
+  await expect(
+    client
+      .namespace('test')
+      .write({ upsert_columns: { id: [1], vector: [[0.1]] } }, { signal: controller.signal }),
+  ).rejects.toThrow(APIUserAbortError);
 });

--- a/tests/respondAsync.test.ts
+++ b/tests/respondAsync.test.ts
@@ -1,0 +1,189 @@
+import Turbopuffer, {
+  APIConnectionTimeoutError,
+  InternalServerError,
+  NotFoundError,
+} from '@turbopuffer/turbopuffer';
+import * as RespondAsync from '@turbopuffer/turbopuffer/internal/custom/respond-async';
+
+const BASE_URL = 'http://localhost:5000';
+const POLL_URL = `${BASE_URL}/v1/namespaces/test/operations/op-abc`;
+
+const WRITE_OK_BODY = {
+  billing: {
+    billable_logical_bytes_written: 0,
+    billable_logical_bytes_returned: 0,
+  },
+  message: 'OK',
+  rows_affected: 1,
+  status: 'OK',
+};
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+function asyncAppliedResponse(location: string) {
+  return new Response(null, {
+    status: 202,
+    headers: { 'preference-applied': 'respond-async', location },
+  });
+}
+
+beforeEach(() => {
+  RespondAsync.config.pollIntervalMs = 0;
+});
+
+afterEach(() => {
+  RespondAsync.config.pollIntervalMs = 1000;
+});
+
+test('prefer header is sent on requests', async () => {
+  let capturedHeaders: Headers | undefined;
+  const testFetch = async (url: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
+    capturedHeaders = init.headers as Headers;
+    return jsonResponse(200, WRITE_OK_BODY);
+  };
+
+  const client = new Turbopuffer({ baseURL: BASE_URL, apiKey: 'tpuf_A1...', fetch: testFetch });
+  await client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } });
+
+  expect(capturedHeaders?.get('prefer')).toEqual('respond-async');
+});
+
+test('sync response passes through', async () => {
+  let calls = 0;
+  const testFetch = async (): Promise<Response> => {
+    calls++;
+    return jsonResponse(200, WRITE_OK_BODY);
+  };
+
+  const client = new Turbopuffer({ baseURL: BASE_URL, apiKey: 'tpuf_A1...', fetch: testFetch });
+  const resp = await client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } });
+
+  expect(calls).toEqual(1);
+  expect(resp.status).toEqual('OK');
+  expect(resp.rows_affected).toEqual(1);
+});
+
+test('unrelated 202 passes through', async () => {
+  let calls = 0;
+  const testFetch = async (): Promise<Response> => {
+    calls++;
+    return jsonResponse(202, WRITE_OK_BODY);
+  };
+
+  const client = new Turbopuffer({ baseURL: BASE_URL, apiKey: 'tpuf_A1...', fetch: testFetch });
+  const resp = await client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } });
+
+  expect(calls).toEqual(1);
+  expect(resp.status).toEqual('OK');
+});
+
+test('async response is polled to success', async () => {
+  const fetches: { url: string; headers: Headers }[] = [];
+  const responses: Response[] = [
+    asyncAppliedResponse(POLL_URL),
+    jsonResponse(200, { status: 'running' }),
+    jsonResponse(200, { status: 'running' }),
+    jsonResponse(200, { status: 'finished', result: { success: WRITE_OK_BODY } }),
+  ];
+
+  const testFetch = async (url: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
+    fetches.push({ url: String(url), headers: init.headers as Headers });
+    return responses.shift()!;
+  };
+
+  const client = new Turbopuffer({ baseURL: BASE_URL, apiKey: 'tpuf_A1...', fetch: testFetch });
+  const resp = await client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } });
+
+  expect(fetches).toHaveLength(4);
+  expect(resp.status).toEqual('OK');
+  expect(resp.rows_affected).toEqual(1);
+  for (let i = 1; i < fetches.length; i++) {
+    // Auth propagates to polls.
+    expect(fetches[i]?.headers.get('authorization')).toEqual('Bearer tpuf_A1...');
+    // Prefer is not sent on poll requests.
+    expect(fetches[i]?.headers.has('prefer')).toBe(false);
+    expect(String(fetches[i]?.url)).toEqual(POLL_URL);
+  }
+});
+
+test('poll error result throws matching status error', async () => {
+  const responses: Response[] = [
+    asyncAppliedResponse(POLL_URL),
+    jsonResponse(200, {
+      status: 'finished',
+      result: { error: { status_code: 404, detail: { message: 'namespace not found' } } },
+    }),
+  ];
+  const testFetch = async (): Promise<Response> => responses.shift()!;
+
+  const client = new Turbopuffer({ baseURL: BASE_URL, apiKey: 'tpuf_A1...', fetch: testFetch });
+  await expect(
+    client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } }),
+  ).rejects.toThrow(NotFoundError);
+});
+
+test('transient poll error is retried', async () => {
+  const responses: Response[] = [
+    asyncAppliedResponse(POLL_URL),
+    new Response(null, { status: 503, headers: { 'retry-after-ms': '0' } }),
+    new Response(null, { status: 503, headers: { 'retry-after-ms': '0' } }),
+    jsonResponse(200, { status: 'finished', result: { success: WRITE_OK_BODY } }),
+  ];
+  let calls = 0;
+  const testFetch = async (): Promise<Response> => {
+    calls++;
+    return responses.shift()!;
+  };
+
+  const client = new Turbopuffer({ baseURL: BASE_URL, apiKey: 'tpuf_A1...', fetch: testFetch });
+  const resp = await client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } });
+
+  expect(calls).toEqual(4);
+  expect(resp.status).toEqual('OK');
+});
+
+test('poll timeout throws APIConnectionTimeoutError', async () => {
+  const testFetch = async (url: string | URL | Request): Promise<Response> => {
+    if (String(url) === POLL_URL) return jsonResponse(200, { status: 'running' });
+    return asyncAppliedResponse(POLL_URL);
+  };
+
+  const client = new Turbopuffer({
+    baseURL: BASE_URL,
+    apiKey: 'tpuf_A1...',
+    fetch: testFetch,
+    timeout: 50,
+  });
+
+  await expect(
+    client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } }),
+  ).rejects.toThrow(APIConnectionTimeoutError);
+});
+
+test('persistent poll error throws', async () => {
+  let polls = 0;
+  const testFetch = async (url: string | URL | Request): Promise<Response> => {
+    if (String(url) === POLL_URL) {
+      polls++;
+      return new Response(null, { status: 503 });
+    }
+    return asyncAppliedResponse(POLL_URL);
+  };
+
+  const client = new Turbopuffer({
+    baseURL: BASE_URL,
+    apiKey: 'tpuf_A1...',
+    fetch: testFetch,
+    maxRetries: 0,
+  });
+
+  await expect(
+    client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } }),
+  ).rejects.toThrow(InternalServerError);
+  expect(polls).toEqual(1);
+});


### PR DESCRIPTION
This adds support for transparent async polling against tpuf APIs that support it. The SDK unconditionally sets the `prefer: respond-async` header on all API calls, then detects and handles async responses by polling them until the final state.

# Example

```ts
import Turbopuffer from '@turbopuffer/turbopuffer';

const API_KEY = '...';
const BASE_URL = 'http://localhost:3001';
const NAMESPACE = 'respond-async-smoke';

const UPSERT_COLUMNS = {
  id: [1, 2, 3, 4, 5],
  vector: [
    [0.1, 0.2],
    [0.2, 0.1],
    [0.3, 0.3],
    [0.4, 0.1],
    [0.5, 0.2],
  ],
};

async function main() {
  const client = new Turbopuffer({ apiKey: API_KEY, baseURL: BASE_URL, logLevel: 'info' });
  const ns = client.namespace(NAMESPACE);

  console.log('\n=== seeding namespace ===');
  await ns.write({ upsert_columns: UPSERT_COLUMNS, distance_metric: 'euclidean_squared' });

  console.log('\n=== calling recall (expect 202 + polling cycle) ===');
  const result = await ns.recall({ num: 2, top_k: 3 });

  console.log('\n=== final recall result ===');
  console.log(result);
}

main().catch((err) => {
  console.error(err);
  process.exit(1);
});
```

Output:

```
=== seeding namespace ===
[log_4404c3] post http://localhost:3001/v2/namespaces/respond-async-smoke succeeded with status 200 in 2421ms

=== calling recall (expect 202 + polling cycle) ===
[log_613649] post http://localhost:3001/v1/namespaces/respond-async-smoke/_debug/recall succeeded with status 202 in 1592ms
[log_1f37da] get http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e40a7-e40a-773b-99c8-cdadc89d177f succeeded with status 200 in 167ms
[log_3f14a6] get http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e40a7-e40a-773b-99c8-cdadc89d177f succeeded with status 200 in 173ms
[log_5ed98a] get http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e40a7-e40a-773b-99c8-cdadc89d177f succeeded with status 200 in 214ms
[log_38c222] get http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e40a7-e40a-773b-99c8-cdadc89d177f succeeded with status 200 in 230ms
[log_7d4d14] get http://localhost:3001/v1/namespaces/respond-async-smoke/operations/tpuf-job-rec-019e40a7-e40a-773b-99c8-cdadc89d177f succeeded with status 200 in 172ms

=== final recall result ===
{ avg_ann_count: 3, avg_exhaustive_count: 3, avg_recall: 1 }
✨  Done in 9.49s.
```