### PR TITLE
fix: reject malicious poll locations

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -642,7 +642,7 @@ export class Turbopuffer {
       }),
     );
 
-    response = await RespondAsync.maybePoll(this, response, options, clock);
+    response = await RespondAsync.maybePoll(this, response, url, options, clock);
 
     clock.deserializeStart = performance.now();
 

--- a/src/internal/custom/respond-async.ts
+++ b/src/internal/custom/respond-async.ts
@@ -41,16 +41,13 @@ export function prepareOptions(options: FinalRequestOptions): void {
 export async function maybePoll(
   client: Turbopuffer,
   response: Response,
+  requestURL: string,
   options: FinalRequestOptions,
   clock: RequestClock,
 ): Promise<Response> {
   if (!respondAsyncApplied(response)) return response;
 
-  const location = response.headers.get(HEADER_LOCATION);
-  if (!location) {
-    throw new Errors.TurbopufferError('server returned async response without a `location` header');
-  }
-
+  const location = extractLocation(response, requestURL);
   const timeout = new Timeout(options.timeout ?? client.timeout);
 
   while (true) {
@@ -69,6 +66,29 @@ export async function maybePoll(
 
     await sleep(timeout.sleepDurationMs());
   }
+}
+
+function extractLocation(response: Response, origURL: string): string {
+  const rawLocation = response.headers.get(HEADER_LOCATION);
+  if (!rawLocation) {
+    throw new Errors.TurbopufferError("server returned async response without a 'Location' header");
+  }
+
+  // Resolve the Location against the original request URL.
+  let resolved: URL;
+  try {
+    resolved = new URL(rawLocation, origURL);
+  } catch {
+    throw new Errors.TurbopufferError(`malformed 'Location' header: ${rawLocation}`);
+  }
+
+  // Reject a Location pointing at a different origin, to prevent API key exfiltration.
+  const requestOrigin = new URL(origURL).origin;
+  if (resolved.origin !== requestOrigin) {
+    throw new Errors.TurbopufferError(`'Location' origin does not match request origin: ${rawLocation}`);
+  }
+
+  return resolved.toString();
 }
 
 function resolvePollResponse(body: PollBody, clock: RequestClock): Response | null {

--- a/tests/respondAsync.test.ts
+++ b/tests/respondAsync.test.ts
@@ -3,6 +3,7 @@ import Turbopuffer, {
   APIUserAbortError,
   InternalServerError,
   NotFoundError,
+  TurbopufferError,
 } from '@turbopuffer/turbopuffer';
 import * as RespondAsync from '@turbopuffer/turbopuffer/internal/custom/respond-async';
 
@@ -110,6 +111,25 @@ test('async response is polled to success', async () => {
     expect(fetches[i]?.headers.has('prefer')).toBe(false);
     expect(String(fetches[i]?.url)).toEqual(POLL_URL);
   }
+});
+
+test.each([
+  'https://evil.example.com/v1/ops/op-x',
+  '//evil.example.com/v1/ops/op-x',
+  'http://api.turbopuffer.com/v1/ops/op-x',
+  'http://host:notaport/x',
+])('bad poll location is rejected: %s', async (badLocation) => {
+  let calls = 0;
+  const testFetch = async (): Promise<Response> => {
+    calls++;
+    return asyncAppliedResponse(badLocation);
+  };
+
+  const client = new Turbopuffer({ baseURL: BASE_URL, apiKey: 'tpuf_A1...', fetch: testFetch });
+  await expect(
+    client.namespace('test').write({ upsert_columns: { id: [1], vector: [[0.1]] } }),
+  ).rejects.toThrow(TurbopufferError);
+  expect(calls).toEqual(1);
 });
 
 test('poll error result throws matching status error', async () => {


### PR DESCRIPTION
This fixes a minor security issue where the client wouldn't check the origin of the async response `Location` header before starting to poll it, allowing a man-in-the-middle to send poll requests (including API credentials) to arbitrary locations. This is a minor security issue, as such a man-in-the-middle would likely already know the API credentials from observing the initial authenticated request.

The fix is to compare the poll origin with the one from the original request, and reject if they differ.