### PR TITLE
fix: type rerank_by parameter as RerankBy

### DIFF
--- a/src/resources/namespaces.ts
+++ b/src/resources/namespaces.ts
@@ -5,7 +5,7 @@ import * as NamespacesAPI from './namespaces';
 import { APIPromise } from '../core/api-promise';
 import { RequestOptions } from '../internal/request-options';
 import { path } from '../internal/utils/path';
-import { AggregateBy, Filter, GroupBy, RankBy } from './custom';
+import { AggregateBy, Filter, GroupBy, RankBy, RerankBy } from './custom';
 import { ClientPerformance } from '../internal/custom/performance';
 import { NotFoundError } from '../error';
 
@@ -1370,7 +1370,7 @@ export interface NamespaceMultiQueryParams {
    * Body param: How to combine the rows returned by each sub-query into a single
    * ranked list.
    */
-  rerank_by?: unknown;
+  rerank_by?: RerankBy;
 
   /**
    * Body param: The encoding to use for vectors in the response.

--- a/tests/api-resources/namespaces.test.ts
+++ b/tests/api-resources/namespaces.test.ts
@@ -164,7 +164,7 @@ describe('resource namespaces', () => {
         },
       ],
       consistency: { level: 'strong' },
-      rerank_by: {},
+      rerank_by: ['RRF'],
       vector_encoding: 'float',
     });
   });


### PR DESCRIPTION
## Summary
- Stainless leaves the `rerank_by` parameter typed as `unknown`. This wires it to the already-generated `RerankBy` type so callers get a proper signature.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Updated generated test that previously passed `rerank_by: {}` to a valid `['RRF']` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)