### PR TITLE
feat: merge ComputeAttributes into Expr union (preview of spec #10694)

### DIFF
--- a/src/resources/custom.ts
+++ b/src/resources/custom.ts
@@ -14,23 +14,22 @@ export type AggregateBy<T = Record<string, any>> =
   | ['Count']
   | ['Sum', keyof T & string]
   | ['Count', keyof T & string];
-export type ComputeAttributes<T = Record<string, any>> =
-  | ComputeAttributesVectorDist<T>
-  | ComputeAttributesHighlight<T>
-  | ComputeAttributesHighlightWithConfig<T>
+export type Expr<T = Record<string, any>> =
+  | ExprRefNew<T>
+  | ['Embed', string]
+  | ['Embed', string, EmbedParams]
+  | ExprVectorDist<T>
+  | ExprHighlight<T>
+  | ExprHighlightWithConfig<T>
   | RankBy<T>;
-export type ComputeAttributesHighlight<T = Record<string, any>> = ['Highlight', keyof T & string];
-export type ComputeAttributesHighlightWithConfig<T = Record<string, any>> = [
+export type ExprHighlight<T = Record<string, any>> = ['Highlight', keyof T & string];
+export type ExprHighlightWithConfig<T = Record<string, any>> = [
   'Highlight',
   keyof T & string,
   HighlightConfigParams,
 ];
-export type ComputeAttributesVectorDist<T = Record<string, any>> = [keyof T & string, 'VectorDist', number[]];
-export type Expr<T = Record<string, any>> =
-  | ExprRefNew<T>
-  | ['Embed', string]
-  | ['Embed', string, EmbedParams];
 export type ExprRefNew<T = Record<string, any>> = { $ref_new: keyof T & string };
+export type ExprVectorDist<T = Record<string, any>> = [keyof T & string, 'VectorDist', number[]];
 export type Filter<T = Record<string, any>> =
   | [keyof T & string, 'Eq', any]
   | [keyof T & string, 'NotEq', any]

--- a/src/resources/custom.ts
+++ b/src/resources/custom.ts
@@ -14,22 +14,23 @@ export type AggregateBy<T = Record<string, any>> =
   | ['Count']
   | ['Sum', keyof T & string]
   | ['Count', keyof T & string];
-export type Expr<T = Record<string, any>> =
-  | ExprRefNew<T>
-  | ['Embed', string]
-  | ['Embed', string, EmbedParams]
-  | ExprVectorDist<T>
-  | ExprHighlight<T>
-  | ExprHighlightWithConfig<T>
+export type ComputeAttributes<T = Record<string, any>> =
+  | ComputeAttributesVectorDist<T>
+  | ComputeAttributesHighlight<T>
+  | ComputeAttributesHighlightWithConfig<T>
   | RankBy<T>;
-export type ExprHighlight<T = Record<string, any>> = ['Highlight', keyof T & string];
-export type ExprHighlightWithConfig<T = Record<string, any>> = [
+export type ComputeAttributesHighlight<T = Record<string, any>> = ['Highlight', keyof T & string];
+export type ComputeAttributesHighlightWithConfig<T = Record<string, any>> = [
   'Highlight',
   keyof T & string,
   HighlightConfigParams,
 ];
+export type ComputeAttributesVectorDist<T = Record<string, any>> = [keyof T & string, 'VectorDist', number[]];
+export type Expr<T = Record<string, any>> =
+  | ExprRefNew<T>
+  | ['Embed', string]
+  | ['Embed', string, EmbedParams];
 export type ExprRefNew<T = Record<string, any>> = { $ref_new: keyof T & string };
-export type ExprVectorDist<T = Record<string, any>> = [keyof T & string, 'VectorDist', number[]];
 export type Filter<T = Record<string, any>> =
   | [keyof T & string, 'Eq', any]
   | [keyof T & string, 'NotEq', any]

--- a/src/resources/namespaces.ts
+++ b/src/resources/namespaces.ts
@@ -5,7 +5,7 @@ import * as NamespacesAPI from './namespaces';
 import { APIPromise } from '../core/api-promise';
 import { RequestOptions } from '../internal/request-options';
 import { path } from '../internal/utils/path';
-import { AggregateBy, ComputeAttributes, Filter, GroupBy, RankBy, RerankBy } from './custom';
+import { AggregateBy, Expr, Filter, GroupBy, RankBy, RerankBy } from './custom';
 import { ClientPerformance } from '../internal/custom/performance';
 import { NotFoundError } from '../error';
 
@@ -1358,7 +1358,7 @@ export interface NamespaceExplainQueryParams {
    * key is the name of the computed attribute; each value is an expression
    * describing how to compute it.
    */
-  compute_attributes?: { [key: string]: ComputeAttributes };
+  compute_attributes?: { [key: string]: Expr };
 
   /**
    * Body param: The consistency level for a query.
@@ -1489,7 +1489,7 @@ export namespace NamespaceMultiQueryParams {
      * name of the computed attribute; each value is an expression describing how to
      * compute it.
      */
-    compute_attributes?: { [key: string]: ComputeAttributes };
+    compute_attributes?: { [key: string]: Expr };
 
     /**
      * A function used to calculate vector similarity.
@@ -1568,7 +1568,7 @@ export interface NamespaceQueryParams {
    * key is the name of the computed attribute; each value is an expression
    * describing how to compute it.
    */
-  compute_attributes?: { [key: string]: ComputeAttributes };
+  compute_attributes?: { [key: string]: Expr };
 
   /**
    * Body param: The consistency level for a query.


### PR DESCRIPTION
## Preview — depends on spec PR #10694

Shows what the TypeScript SDK looks like after [turbopuffer/turbopuffer#10694](https://github.com/turbopuffer/turbopuffer/pull/10694) ("merge Expr and ComputeAttributes into a single Expr union") lands. Generated by running apigen against that PR's `spec/openapi.yml`.

### `src/resources/custom.ts` — auto-generated (apigen)
- `ComputeAttributes` union **deleted**
- Arms renamed and folded into `Expr`: `ComputeAttributesVectorDist → ExprVectorDist`, `ComputeAttributesHighlight → ExprHighlight`, `ComputeAttributesHighlightWithConfig → ExprHighlightWithConfig`
- `Expr` is now `ExprRefNew | ['Embed', …] | ['Embed', …, EmbedParams] | ExprVectorDist | ExprHighlight | ExprHighlightWithConfig | RankBy`

### `src/resources/namespaces.ts` — the only hand edit (custom override)
- `compute_attributes` retargeted `{ [key: string]: ComputeAttributes }` → `{ [key: string]: Expr }` (import + 3 field sites)

Typechecks clean (`tsc --noEmit` exit 0).

### ⚠️ Semantic widening to confirm
`compute_attributes` values now accept the **entire** `Expr` union — including `['Embed', …]` and `{ $ref_new }`, which the old `ComputeAttributes` type did not. Confirm the API actually accepts those in a `compute_attributes` position; otherwise this type is too permissive.

### Rollout note
Same two-part change applies to go / python / java / csharp: apigen regenerates the union for free, and each SDK's one custom override swaps `ComputeAttributes → Expr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
