### PR TITLE
feat: type compute_attributes as the Expr union (turbopuffer#10694)

### DIFF
--- a/src/resources/custom.ts
+++ b/src/resources/custom.ts
@@ -14,23 +14,22 @@ export type AggregateBy<T = Record<string, any>> =
   | ['Count']
   | ['Sum', keyof T & string]
   | ['Count', keyof T & string];
-export type ComputeAttributes<T = Record<string, any>> =
-  | ComputeAttributesVectorDist<T>
-  | ComputeAttributesHighlight<T>
-  | ComputeAttributesHighlightWithConfig<T>
+export type Expr<T = Record<string, any>> =
+  | ExprRefNew<T>
+  | ['Embed', string]
+  | ['Embed', string, EmbedParams]
+  | ExprVectorDist<T>
+  | ExprHighlight<T>
+  | ExprHighlightWithConfig<T>
   | RankBy<T>;
-export type ComputeAttributesHighlight<T = Record<string, any>> = ['Highlight', keyof T & string];
-export type ComputeAttributesHighlightWithConfig<T = Record<string, any>> = [
+export type ExprHighlight<T = Record<string, any>> = ['Highlight', keyof T & string];
+export type ExprHighlightWithConfig<T = Record<string, any>> = [
   'Highlight',
   keyof T & string,
   HighlightConfigParams,
 ];
-export type ComputeAttributesVectorDist<T = Record<string, any>> = [keyof T & string, 'VectorDist', number[]];
-export type Expr<T = Record<string, any>> =
-  | ExprRefNew<T>
-  | ['Embed', string]
-  | ['Embed', string, EmbedParams];
 export type ExprRefNew<T = Record<string, any>> = { $ref_new: keyof T & string };
+export type ExprVectorDist<T = Record<string, any>> = [keyof T & string, 'VectorDist', number[]];
 export type Filter<T = Record<string, any>> =
   | [keyof T & string, 'Eq', any]
   | [keyof T & string, 'NotEq', any]

--- a/src/resources/namespaces.ts
+++ b/src/resources/namespaces.ts
@@ -5,7 +5,7 @@ import * as NamespacesAPI from './namespaces';
 import { APIPromise } from '../core/api-promise';
 import { RequestOptions } from '../internal/request-options';
 import { path } from '../internal/utils/path';
-import { AggregateBy, ComputeAttributes, Filter, GroupBy, RankBy, RerankBy } from './custom';
+import { AggregateBy, Expr, Filter, GroupBy, RankBy, RerankBy } from './custom';
 import { ClientPerformance } from '../internal/custom/performance';
 import { NotFoundError } from '../error';
 
@@ -1358,7 +1358,7 @@ export interface NamespaceExplainQueryParams {
    * key is the name of the computed attribute; each value is an expression
    * describing how to compute it.
    */
-  compute_attributes?: { [key: string]: ComputeAttributes };
+  compute_attributes?: { [key: string]: Expr };
 
   /**
    * Body param: The consistency level for a query.
@@ -1489,7 +1489,7 @@ export namespace NamespaceMultiQueryParams {
      * name of the computed attribute; each value is an expression describing how to
      * compute it.
      */
-    compute_attributes?: { [key: string]: ComputeAttributes };
+    compute_attributes?: { [key: string]: Expr };
 
     /**
      * A function used to calculate vector similarity.
@@ -1568,7 +1568,7 @@ export interface NamespaceQueryParams {
    * key is the name of the computed attribute; each value is an expression
    * describing how to compute it.
    */
-  compute_attributes?: { [key: string]: ComputeAttributes };
+  compute_attributes?: { [key: string]: Expr };
 
   /**
    * Body param: The consistency level for a query.


### PR DESCRIPTION
Follows spec turbopuffer/turbopuffer#10694 (merge Expr and ComputeAttributes into a single Expr union), now merged.

**Commit 1 (automated codegen):** `scripts/gen` — apigen folds `ComputeAttributes` into `Expr` in `custom.ts`.
**Commit 2 (hand-rolled):** retarget the `compute_attributes` override in `namespaces.ts` from `ComputeAttributes` → `Expr`.

Verified: full `scripts/lint` green locally (gen-drift clean, tsc, attw, publint). The two arms newly allowed (`Embed`, `$ref_new`) are rejected server-side, so the wider type is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)